### PR TITLE
improve type information in command output formatting

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -84,6 +84,22 @@ impl std::fmt::Display for FerryValue {
             FerryValue::Str(s) => write!(f, "{s}"),
             FerryValue::Boolean(b) => write!(f, "{b}"),
             FerryValue::Unit => write!(f, "[unit]"),
+<<<<<<< HEAD
+=======
+            FerryValue::List(l) => {
+                let mut formatting = String::new();
+                formatting.push_str("[");
+                let mut items = l.iter().peekable();
+                while let Some(item) = items.next() {
+                    formatting.push_str(format!("{item}").as_str());
+                    if !items.peek().is_none() {
+                        formatting.push_str(", ");
+                    }
+                }
+                formatting.push_str("]");
+                write!(f, "{formatting}")
+            }
+>>>>>>> 7c56c1d (improve type information in command output formatting)
         }
     }
 }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -166,26 +166,47 @@ impl std::fmt::Display for Expr {
             Expr::Literal(l) => match l {
                 Lit::Number {
                     value,
-                    expr_type: _,
+                    expr_type,
                     span: _,
                     token: _,
-                } => write!(f, "{value}"),
+                } => write!(f, "{expr_type}: {value}"),
                 Lit::Str {
                     value,
-                    expr_type: _,
+                    expr_type,
                     span: _,
                     token: _,
-                } => write!(f, "{value}"),
+                } => write!(f, "{expr_type}: {value}"),
                 Lit::Bool {
                     value,
-                    expr_type: _,
+                    expr_type,
                     span: _,
                     token: _,
-                } => write!(f, "{value}"),
+                } => write!(f, "{expr_type}: {value}"),
                 Lit::Undefined {
                     expr_type,
                     token: _,
                 } => write!(f, "{expr_type}"),
+<<<<<<< HEAD
+=======
+                Lit::List {
+                    token: _,
+                    contents,
+                    expr_type,
+                    span: _,
+                } => {
+                    let mut formatting = String::new();
+                    formatting.push_str("[");
+                    let mut items = contents.iter().peekable();
+                    while let Some(item) = items.next() {
+                        formatting.push_str(format!("{item}").as_str());
+                        if !items.peek().is_none() {
+                            formatting.push_str(", ");
+                        }
+                    }
+                    formatting.push_str("]");
+                    write!(f, "{expr_type}: {formatting}")
+                }
+>>>>>>> 7c56c1d (improve type information in command output formatting)
             },
             Expr::Binary(b) => match b.operator.get_token_type() {
                 TT::Operator(o) => match o {
@@ -208,30 +229,53 @@ impl std::fmt::Display for Expr {
                 },
                 _ => unreachable!(),
             },
-            Expr::Variable(v) => write!(f, "{}", v.name),
+            Expr::Variable(v) => write!(f, "{}: {}", v.name, v.expr_type),
             Expr::Assign(a) => {
                 if a.value.is_some() {
-                    write!(f, "{} is {}", a.var, a.value.clone().unwrap())
+                    write!(
+                        f,
+                        "{}: {} is {}",
+                        a.var,
+                        a.expr_type,
+                        a.value.clone().unwrap()
+                    )
                 } else {
-                    write!(f, "{} is NULL", a.var)
+                    write!(f, "{}: {} is NULL", a.var, a.expr_type)
                 }
             }
             Expr::If(i) => {
                 if i.else_expr.is_some() {
                     write!(
                         f,
-                        "if {} then: {} else: {}",
+                        "if {} then: {} else: {} (type: {})",
                         i.condition,
                         i.then_expr,
-                        i.else_expr.clone().unwrap()
+                        i.else_expr.clone().unwrap(),
+                        i.expr_type,
                     )
                 } else {
-                    write!(f, "if {} then: {}", i.condition, i.then_expr)
+                    write!(
+                        f,
+                        "if {} then: {} (type: {})",
+                        i.condition, i.then_expr, i.expr_type
+                    )
                 }
             }
-            Expr::Group(g) => write!(f, "( {} )", g.contents),
-            Expr::Binding(b) => write!(f, "let {}", b.name),
-            Expr::Loop(_l) => write!(f, "loop"),
+            Expr::Group(g) => write!(f, "{}: ( {} )", g.expr_type, g.contents),
+            Expr::Binding(b) => {
+                if b.value.is_some() {
+                    write!(
+                        f,
+                        "let {}: {} = {}",
+                        b.name,
+                        b.expr_type,
+                        b.value.clone().unwrap()
+                    )
+                } else {
+                    write!(f, "let {}: {}", b.name, b.expr_type)
+                }
+            }
+            Expr::Loop(l) => write!(f, "loop (type: {})", l.expr_type),
         }
     }
 }


### PR DESCRIPTION
Type information in the `!type` command was not displayed except under very specific circumstances; this addresses this and formats the information for `Expr` and `FerryValue` objects.