### PR TITLE
Add lists to supported data elements

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -228,6 +228,17 @@ impl ExprVisitor<FerryResult<FerryValue>, &mut FerryState> for &mut FerryInterpr
                         span: *op.get_span(),
                     }),
                 },
+                Op::Cons => match (left, right) {
+                    (Some(FerryValue::List(a)), Some(FerryValue::List(b))) => {
+                        let value = vec![a, b].concat();
+                        Ok(Some(FerryValue::List(value)))
+                    }
+
+                    _ => Err(FerryInterpreterError::InvalidOperation {
+                        help: "Operator only takes values of type List".into(),
+                        span: *op.get_span(),
+                    }),
+                },
 
                 _ => Err(FerryInterpreterError::InvalidOperation {
                     help: "this was not a binary op".into(),

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -97,10 +97,10 @@ impl ExprVisitor<FerryResult<FerryValue>, &mut FerryState> for &mut FerryInterpr
                 token: _,
             } => Ok(Some(FerryValue::Unit)),
             SLit::List {
-                token,
+                token: _,
                 contents,
-                expr_type,
-                span,
+                expr_type: _,
+                span: _,
             } => {
                 let mut values: Vec<FerryValue> = Vec::new();
                 for c in contents {
@@ -239,11 +239,10 @@ impl ExprVisitor<FerryResult<FerryValue>, &mut FerryState> for &mut FerryInterpr
                         span: *op.get_span(),
                     }),
                 },
-
-                _ => Err(FerryInterpreterError::InvalidOperation {
-                    help: "this was not a binary op".into(),
-                    span: *binary.operator.get_span(),
-                }),
+                // _ => Err(FerryInterpreterError::InvalidOperation {
+                //     help: "this was not a binary op".into(),
+                //     span: *binary.operator.get_span(),
+                // }),
             },
             _ => Ok(None),
         }
@@ -349,7 +348,7 @@ impl ExprVisitor<FerryResult<FerryValue>, &mut FerryState> for &mut FerryInterpr
         unary: &mut crate::syntax::Unary,
         state: &mut FerryState,
     ) -> FerryResult<FerryValue> {
-        let right = self.evaluate(&mut unary.rhs, state)?;
+        let _right = self.evaluate(&mut unary.rhs, state)?;
 
         match unary.operator.get_token_type() {
             TT::Operator(o) => match o {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -96,6 +96,15 @@ impl ExprVisitor<FerryResult<FerryValue>, &mut FerryState> for &mut FerryInterpr
                 expr_type: _,
                 token: _,
             } => Ok(Some(FerryValue::Unit)),
+            SLit::List {
+                token,
+                contents,
+                expr_type,
+                span,
+            } => Err(FerryInterpreterError::Unimplemented {
+                help: "Unimplemented feature".into(),
+                span: *span,
+            }),
         }
     }
 

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -3,7 +3,10 @@ use thiserror::Error;
 
 use crate::{
     state::{FerryState, FerryValue},
-    syntax::{walk_expr, Binary, Expr, ExprVisitor, Group, Lit as SLit, Variable},
+    syntax::{
+        walk_expr, Assign, Binary, Binding, Expr, ExprVisitor, Group, If, Lit as SLit, Loop, Unary,
+        Variable,
+    },
     token::{Op, TokenType as TT},
 };
 
@@ -258,7 +261,7 @@ impl ExprVisitor<FerryResult<FerryValue>, &mut FerryState> for &mut FerryInterpr
 
     fn visit_assign(
         &mut self,
-        assign: &mut crate::syntax::Assign,
+        assign: &mut Assign,
         state: &mut FerryState,
     ) -> FerryResult<FerryValue> {
         if let Some(v) = &mut assign.value {
@@ -272,7 +275,7 @@ impl ExprVisitor<FerryResult<FerryValue>, &mut FerryState> for &mut FerryInterpr
 
     fn visit_if_expr(
         &mut self,
-        if_expr: &mut crate::syntax::If,
+        if_expr: &mut If,
         state: &mut FerryState,
     ) -> FerryResult<FerryValue> {
         if let Some(conditional) = self.evaluate(&mut if_expr.condition, state)? {
@@ -299,7 +302,7 @@ impl ExprVisitor<FerryResult<FerryValue>, &mut FerryState> for &mut FerryInterpr
 
     fn visit_binding(
         &mut self,
-        binding: &mut crate::syntax::Binding,
+        binding: &mut Binding,
         state: &mut FerryState,
     ) -> FerryResult<FerryValue> {
         if let Some(v) = &mut binding.value {
@@ -313,7 +316,7 @@ impl ExprVisitor<FerryResult<FerryValue>, &mut FerryState> for &mut FerryInterpr
 
     fn visit_loop(
         &mut self,
-        loop_expr: &mut crate::syntax::Loop,
+        loop_expr: &mut Loop,
         state: &mut FerryState,
     ) -> FerryResult<FerryValue> {
         if let Some(cond) = &mut loop_expr.condition {
@@ -345,7 +348,7 @@ impl ExprVisitor<FerryResult<FerryValue>, &mut FerryState> for &mut FerryInterpr
 
     fn visit_unary(
         &mut self,
-        unary: &mut crate::syntax::Unary,
+        unary: &mut Unary,
         state: &mut FerryState,
     ) -> FerryResult<FerryValue> {
         let _right = self.evaluate(&mut unary.rhs, state)?;

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -230,7 +230,7 @@ impl ExprVisitor<FerryResult<FerryValue>, &mut FerryState> for &mut FerryInterpr
                 },
                 Op::Cons => match (left, right) {
                     (Some(FerryValue::List(a)), Some(FerryValue::List(b))) => {
-                        let value = vec![a, b].concat();
+                        let value = [a, b].concat();
                         Ok(Some(FerryValue::List(value)))
                     }
 
@@ -351,12 +351,10 @@ impl ExprVisitor<FerryResult<FerryValue>, &mut FerryState> for &mut FerryInterpr
         let _right = self.evaluate(&mut unary.rhs, state)?;
 
         match unary.operator.get_token_type() {
-            TT::Operator(o) => match o {
-                _ => Err(FerryInterpreterError::InvalidOperation {
-                    help: "Invalid unary operator".into(),
-                    span: *unary.operator.get_span(),
-                }),
-            },
+            TT::Operator(o) => Err(FerryInterpreterError::InvalidOperation {
+                help: "Invalid unary operator".into(),
+                span: *unary.operator.get_span(),
+            }),
             _ => Err(FerryInterpreterError::InvalidOperation {
                 help: "Invalid unary operator".into(),
                 span: *unary.operator.get_span(),

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -303,6 +303,7 @@ impl FerryValue {
             FerryValue::Str(s) => !s.is_empty(),
             FerryValue::Boolean(b) => *b,
             FerryValue::Unit => false,
+            FerryValue::List(l) => !l.is_empty(),
         }
     }
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -71,7 +71,7 @@ impl ExprVisitor<FerryResult<FerryValue>, &mut FerryState> for &mut FerryInterpr
     fn visit_literal(
         &mut self,
         literal: &mut SLit,
-        _state: &mut FerryState,
+        state: &mut FerryState,
     ) -> FerryResult<FerryValue> {
         match literal {
             SLit::Number {
@@ -101,10 +101,17 @@ impl ExprVisitor<FerryResult<FerryValue>, &mut FerryState> for &mut FerryInterpr
                 contents,
                 expr_type,
                 span,
-            } => Err(FerryInterpreterError::Unimplemented {
-                help: "Unimplemented feature".into(),
-                span: *span,
-            }),
+            } => {
+                let mut values: Vec<FerryValue> = Vec::new();
+                for c in contents {
+                    if let Some(value) = self.evaluate(c, state)? {
+                        values.push(value);
+                    } else {
+                        values.push(FerryValue::Unit);
+                    }
+                }
+                Ok(Some(FerryValue::List(values)))
+            }
         }
     }
 

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -145,6 +145,7 @@ impl<'source> FerryLexer<'source> {
 
                     // list operators
                     "geti" => Some(TT::Operator(Op::GetI)),
+                    "cons" => Some(TT::Operator(Op::Cons)),
                     _ => Some(TT::Identifier(id)),
                 })
             }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -84,6 +84,8 @@ impl<'source> FerryLexer<'source> {
             b':' => Ok(Some(TT::Control(Ctrl::Colon))),
             b'(' => Ok(Some(TT::Control(Ctrl::LeftParen))),
             b')' => Ok(Some(TT::Control(Ctrl::RightParen))),
+            b'[' => Ok(Some(TT::Control(Ctrl::LeftBracket))),
+            b']' => Ok(Some(TT::Control(Ctrl::RightBracket))),
 
             // OPERATORS
             b'+' => Ok(Some(TT::Operator(Op::Add))),

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -86,6 +86,7 @@ impl<'source> FerryLexer<'source> {
             b')' => Ok(Some(TT::Control(Ctrl::RightParen))),
             b'[' => Ok(Some(TT::Control(Ctrl::LeftBracket))),
             b']' => Ok(Some(TT::Control(Ctrl::RightBracket))),
+            b',' => Ok(Some(TT::Control(Ctrl::Comma))),
 
             // OPERATORS
             b'+' => Ok(Some(TT::Operator(Op::Add))),

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -142,6 +142,9 @@ impl<'source> FerryLexer<'source> {
                     // reserved boolean keywords
                     "true" => Some(TT::Value(Val::Boolean(true))),
                     "false" => Some(TT::Value(Val::Boolean(false))),
+
+                    // list operators
+                    "geti" => Some(TT::Operator(Op::GetI)),
                     _ => Some(TT::Identifier(id)),
                 })
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,5 +141,5 @@ fn print_help() {
     println!("!asm:   Print the generated RISC-V assembly (alpha)");
     println!("!exit:");
     println!("!quit:  Quit the REPL");
-    print!("\n");
+    println!();
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -189,6 +189,12 @@ impl FerryParser {
     }
 
     fn s_expression(&mut self, state: &mut FerryState) -> FerryResult<Expr> {
+        let expr = self.list(state)?;
+
+        Ok(expr)
+    }
+
+    fn list(&mut self, state: &mut FerryState) -> FerryResult<Expr> {
         let expr = self.assignment(state)?;
 
         Ok(expr)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,5 +1,3 @@
-use std::slice::RChunks;
-
 use miette::{Diagnostic, Result, SourceSpan};
 use thiserror::Error;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,3 +1,5 @@
+use std::slice::RChunks;
+
 use miette::{Diagnostic, Result, SourceSpan};
 use thiserror::Error;
 
@@ -219,7 +221,7 @@ impl FerryParser {
     }
 
     fn assignment(&mut self, state: &mut FerryState) -> FerryResult<Expr> {
-        let mut expr = self.index(state)?;
+        let mut expr = self.cons(state)?;
 
         if self.matches(&[TT::Operator(Op::Equals)]) {
             let operator = self.previous();
@@ -233,6 +235,23 @@ impl FerryParser {
                     token: operator,
                 });
             }
+        }
+
+        Ok(expr)
+    }
+
+    fn cons(&mut self, state: &mut FerryState) -> FerryResult<Expr> {
+        let mut expr = self.index(state)?;
+
+        if self.matches(&[TT::Operator(Op::Cons)]) {
+            let operator = self.previous();
+            let rhs = Box::new(self.start(state)?);
+            expr = Expr::Binary(Binary {
+                lhs: Box::new(expr.clone()),
+                operator,
+                rhs,
+                expr_type: FerryTyping::Untyped,
+            });
         }
 
         Ok(expr)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -333,16 +333,6 @@ impl FerryParser {
     fn unary(&mut self, state: &mut FerryState) -> FerryResult<Expr> {
         let mut expr = self.target(state)?;
 
-        // if self.matches(&[TT::Operator(Op::GetI)]) {
-        //     let op = self.previous();
-        //     let rhs = Box::new(self.start(state)?);
-        //     expr = Expr::Unary(Unary {
-        //         operator: op,
-        //         rhs,
-        //         expr_type: FerryTyping::Untyped,
-        //     });
-        // }
-
         Ok(expr)
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -219,7 +219,7 @@ impl FerryParser {
     }
 
     fn assignment(&mut self, state: &mut FerryState) -> FerryResult<Expr> {
-        let mut expr = self.comparison(state)?;
+        let mut expr = self.index(state)?;
 
         if self.matches(&[TT::Operator(Op::Equals)]) {
             let operator = self.previous();
@@ -233,6 +233,24 @@ impl FerryParser {
                     token: operator,
                 });
             }
+        }
+
+        Ok(expr)
+    }
+
+    fn index(&mut self, state: &mut FerryState) -> FerryResult<Expr> {
+        let mut expr = self.comparison(state)?;
+
+        if self.matches(&[TT::Operator(Op::GetI)]) {
+            let lhs = Box::new(expr);
+            let op = self.previous();
+            let rhs = Box::new(self.start(state)?);
+            expr = Expr::Binary(Binary {
+                operator: op,
+                lhs,
+                rhs,
+                expr_type: FerryTyping::Untyped,
+            });
         }
 
         Ok(expr)
@@ -279,7 +297,7 @@ impl FerryParser {
     }
 
     fn factor(&mut self, state: &mut FerryState) -> FerryResult<Expr> {
-        let mut expr = self.target(state)?;
+        let mut expr = self.unary(state)?;
 
         if self.matches(&[TT::Operator(Op::Multiply), TT::Operator(Op::Divide)]) {
             let op = self.previous();
@@ -291,6 +309,22 @@ impl FerryParser {
                 expr_type: FerryTyping::Untyped,
             });
         }
+
+        Ok(expr)
+    }
+
+    fn unary(&mut self, state: &mut FerryState) -> FerryResult<Expr> {
+        let mut expr = self.target(state)?;
+
+        // if self.matches(&[TT::Operator(Op::GetI)]) {
+        //     let op = self.previous();
+        //     let rhs = Box::new(self.start(state)?);
+        //     expr = Expr::Unary(Unary {
+        //         operator: op,
+        //         rhs,
+        //         expr_type: FerryTyping::Untyped,
+        //     });
+        // }
 
         Ok(expr)
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -331,7 +331,7 @@ impl FerryParser {
     }
 
     fn unary(&mut self, state: &mut FerryState) -> FerryResult<Expr> {
-        let mut expr = self.target(state)?;
+        let expr = self.target(state)?;
 
         Ok(expr)
     }
@@ -373,7 +373,7 @@ impl FerryParser {
                         expr_type: FerryTyping::Untyped,
                     }));
                     let operator =
-                        FerryToken::new(TT::Operator(Op::GetI), self.peek().get_span().clone());
+                        FerryToken::new(TT::Operator(Op::GetI), *self.peek().get_span());
                     self.consume(&TT::Control(Ctrl::LeftBracket), "expected '[' for index ")?;
                     let rhs = Box::new(self.start(state)?);
                     self.consume(&TT::Control(Ctrl::RightBracket), "expected ']' after '['")?;

--- a/src/riscv.rs
+++ b/src/riscv.rs
@@ -158,6 +158,7 @@ impl ExprVisitor<FerryResult<Instruction>, &mut Vec<Instruction>> for &mut Ferry
                 crate::token::Op::LessEqual => todo!(),
                 crate::token::Op::GreaterEqual => todo!(),
                 crate::token::Op::GetI => todo!(),
+                crate::token::Op::Cons => todo!(),
             },
             _ => unreachable!(),
         };

--- a/src/riscv.rs
+++ b/src/riscv.rs
@@ -97,6 +97,12 @@ impl ExprVisitor<FerryResult<Instruction>, &mut Vec<Instruction>> for &mut Ferry
                 expr_type: _,
                 token: _,
             } => todo!(),
+            Lit::List {
+                token,
+                contents,
+                expr_type,
+                span,
+            } => todo!(),
         }
     }
 

--- a/src/riscv.rs
+++ b/src/riscv.rs
@@ -157,6 +157,7 @@ impl ExprVisitor<FerryResult<Instruction>, &mut Vec<Instruction>> for &mut Ferry
                 crate::token::Op::Equality => todo!(),
                 crate::token::Op::LessEqual => todo!(),
                 crate::token::Op::GreaterEqual => todo!(),
+                crate::token::Op::GetI => todo!(),
             },
             _ => unreachable!(),
         };
@@ -227,6 +228,14 @@ impl ExprVisitor<FerryResult<Instruction>, &mut Vec<Instruction>> for &mut Ferry
         &mut self,
         _loop_expr: &mut crate::syntax::Loop,
         _state: &mut Vec<Instruction>,
+    ) -> FerryResult<Instruction> {
+        todo!()
+    }
+
+    fn visit_unary(
+        &mut self,
+        unary: &mut crate::syntax::Unary,
+        state: &mut Vec<Instruction>,
     ) -> FerryResult<Instruction> {
         todo!()
     }

--- a/src/riscv.rs
+++ b/src/riscv.rs
@@ -3,7 +3,9 @@ use thiserror::Error;
 
 use crate::{
     state::FerryState,
-    syntax::{walk_expr, Binary, Expr, ExprVisitor, Lit, Variable},
+    syntax::{
+        walk_expr, Binary, Binding, Expr, ExprVisitor, Group, If, Lit, Loop, Unary, Variable,
+    },
 };
 
 #[derive(Error, Diagnostic, Debug)]
@@ -203,7 +205,7 @@ impl ExprVisitor<FerryResult<Instruction>, &mut Vec<Instruction>> for &mut Ferry
 
     fn visit_if_expr(
         &mut self,
-        _if_expr: &mut crate::syntax::If,
+        _if_expr: &mut If,
         _state: &mut Vec<Instruction>,
     ) -> FerryResult<Instruction> {
         todo!()
@@ -211,7 +213,7 @@ impl ExprVisitor<FerryResult<Instruction>, &mut Vec<Instruction>> for &mut Ferry
 
     fn visit_group(
         &mut self,
-        _group: &mut crate::syntax::Group,
+        _group: &mut Group,
         _state: &mut Vec<Instruction>,
     ) -> FerryResult<Instruction> {
         todo!()
@@ -219,7 +221,7 @@ impl ExprVisitor<FerryResult<Instruction>, &mut Vec<Instruction>> for &mut Ferry
 
     fn visit_binding(
         &mut self,
-        _binding: &mut crate::syntax::Binding,
+        _binding: &mut Binding,
         _state: &mut Vec<Instruction>,
     ) -> FerryResult<Instruction> {
         todo!()
@@ -227,7 +229,7 @@ impl ExprVisitor<FerryResult<Instruction>, &mut Vec<Instruction>> for &mut Ferry
 
     fn visit_loop(
         &mut self,
-        _loop_expr: &mut crate::syntax::Loop,
+        _loop_expr: &mut Loop,
         _state: &mut Vec<Instruction>,
     ) -> FerryResult<Instruction> {
         todo!()
@@ -235,7 +237,7 @@ impl ExprVisitor<FerryResult<Instruction>, &mut Vec<Instruction>> for &mut Ferry
 
     fn visit_unary(
         &mut self,
-        unary: &mut crate::syntax::Unary,
+        unary: &mut Unary,
         state: &mut Vec<Instruction>,
     ) -> FerryResult<Instruction> {
         todo!()

--- a/src/state.rs
+++ b/src/state.rs
@@ -13,6 +13,7 @@ pub enum FerryValue {
     Number(f64),
     Str(String),
     Boolean(bool),
+    List(Vec<FerryValue>),
     Unit,
 }
 
@@ -67,6 +68,7 @@ impl Typing for FerryValue {
             FerryValue::Str(_) => &FerryType::String,
             FerryValue::Boolean(_) => &FerryType::Boolean,
             FerryValue::Unit => &FerryType::Undefined,
+            FerryValue::List(_) => &FerryType::List,
         }
     }
 }
@@ -84,6 +86,7 @@ impl std::fmt::Display for FerryValue {
             FerryValue::Str(s) => write!(f, "{s}"),
             FerryValue::Boolean(b) => write!(f, "{b}"),
             FerryValue::Unit => write!(f, "[unit]"),
+            FerryValue::List(l) => write!(f, "[{:?}]", l),
         }
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -34,7 +34,7 @@ impl FerryState {
 
     fn update_symbol(&mut self, id: &String, value: Option<FerryValue>) {
         if self.symbols.contains_key(id) {
-            *self.symbols.get_mut(id).unwrap() = value.clone();
+            self.symbols.get_mut(id).unwrap().clone_from(&value);
         }
     }
 
@@ -88,15 +88,15 @@ impl std::fmt::Display for FerryValue {
             FerryValue::Unit => write!(f, "[unit]"),
             FerryValue::List(l) => {
                 let mut formatting = String::new();
-                formatting.push_str("[");
+                formatting.push('[');
                 let mut items = l.iter().peekable();
                 while let Some(item) = items.next() {
                     formatting.push_str(format!("{item}").as_str());
-                    if !items.peek().is_none() {
+                    if items.peek().is_some() {
                         formatting.push_str(", ");
                     }
                 }
-                formatting.push_str("]");
+                formatting.push(']');
                 write!(f, "{formatting}")
             }
         }

--- a/src/state.rs
+++ b/src/state.rs
@@ -86,7 +86,19 @@ impl std::fmt::Display for FerryValue {
             FerryValue::Str(s) => write!(f, "{s}"),
             FerryValue::Boolean(b) => write!(f, "{b}"),
             FerryValue::Unit => write!(f, "[unit]"),
-            FerryValue::List(l) => write!(f, "[{:?}]", l),
+            FerryValue::List(l) => {
+                let mut formatting = String::new();
+                formatting.push_str("[");
+                let mut items = l.iter().peekable();
+                while let Some(item) = items.next() {
+                    formatting.push_str(format!("{item}").as_str());
+                    if !items.peek().is_none() {
+                        formatting.push_str(", ");
+                    }
+                }
+                formatting.push_str("]");
+                write!(f, "{formatting}")
+            }
         }
     }
 }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -216,15 +216,15 @@ impl std::fmt::Display for Expr {
                     span: _,
                 } => {
                     let mut formatting = String::new();
-                    formatting.push_str("[");
+                    formatting.push('[');
                     let mut items = contents.iter().peekable();
                     while let Some(item) = items.next() {
                         formatting.push_str(format!("{item}").as_str());
-                        if !items.peek().is_none() {
+                        if items.peek().is_some() {
                             formatting.push_str(", ");
                         }
                     }
-                    formatting.push_str("]");
+                    formatting.push(']');
                     write!(f, "{expr_type}: {formatting}")
                 }
             },

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -39,6 +39,12 @@ pub enum Lit {
         expr_type: FerryTyping,
         span: SourceSpan,
     },
+    List {
+        token: FerryToken,
+        contents: Vec<Expr>,
+        expr_type: FerryTyping,
+        span: SourceSpan,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -148,6 +154,12 @@ impl Expr {
                     expr_type: _,
                     span: _,
                 } => token,
+                Lit::List {
+                    token,
+                    contents: _,
+                    expr_type: _,
+                    span: _,
+                } => token,
             },
             Expr::Binary(b) => &b.operator,
             Expr::Variable(v) => &v.token,
@@ -186,6 +198,12 @@ impl std::fmt::Display for Expr {
                     expr_type,
                     token: _,
                 } => write!(f, "{expr_type}"),
+                Lit::List {
+                    token: _,
+                    contents,
+                    expr_type: _,
+                    span: _,
+                } => write!(f, "{:?}", contents),
             },
             Expr::Binary(b) => match b.operator.get_token_type() {
                 TT::Operator(o) => match o {

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -1,6 +1,6 @@
 use miette::SourceSpan;
 
-use crate::token::{FerryToken, TokenType as TT};
+use crate::token::{FerryToken, Op, TokenType as TT};
 use crate::types::{FerryType, FerryTyping};
 
 #[derive(Debug, Clone, PartialEq)]
@@ -230,24 +230,24 @@ impl std::fmt::Display for Expr {
             },
             Expr::Binary(b) => match b.operator.get_token_type() {
                 TT::Operator(o) => match o {
-                    crate::token::Op::Add => write!(f, "Add {} {}", b.lhs, b.rhs),
-                    crate::token::Op::Subtract => write!(f, "Subtract {} {}", b.lhs, b.rhs),
-                    crate::token::Op::Multiply => write!(f, "Multiply {} {}", b.lhs, b.rhs),
-                    crate::token::Op::Divide => write!(f, "Divide {} {}", b.lhs, b.rhs),
-                    crate::token::Op::Equals => write!(f, "{} equals {}", b.lhs, b.rhs),
-                    crate::token::Op::LessThan => write!(f, "{} is less than {}", b.lhs, b.rhs),
-                    crate::token::Op::GreaterThan => {
+                    Op::Add => write!(f, "Add {} {}", b.lhs, b.rhs),
+                    Op::Subtract => write!(f, "Subtract {} {}", b.lhs, b.rhs),
+                    Op::Multiply => write!(f, "Multiply {} {}", b.lhs, b.rhs),
+                    Op::Divide => write!(f, "Divide {} {}", b.lhs, b.rhs),
+                    Op::Equals => write!(f, "{} equals {}", b.lhs, b.rhs),
+                    Op::LessThan => write!(f, "{} is less than {}", b.lhs, b.rhs),
+                    Op::GreaterThan => {
                         write!(f, "{} is greater than {}", b.lhs, b.rhs)
                     }
-                    crate::token::Op::Equality => write!(f, "{} is equal to {}", b.lhs, b.rhs),
-                    crate::token::Op::LessEqual => {
+                    Op::Equality => write!(f, "{} is equal to {}", b.lhs, b.rhs),
+                    Op::LessEqual => {
                         write!(f, "{} is less than or equal to {}", b.lhs, b.rhs)
                     }
-                    crate::token::Op::GreaterEqual => {
+                    Op::GreaterEqual => {
                         write!(f, "{} is greater than or equal to {}", b.lhs, b.rhs)
                     }
-                    crate::token::Op::GetI => write!(f, "GetI"),
-                    crate::token::Op::Cons => write!(f, "Cons"),
+                    Op::GetI => write!(f, "GetI"),
+                    Op::Cons => write!(f, "Cons"),
                 },
                 _ => unreachable!(),
             },

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -247,6 +247,7 @@ impl std::fmt::Display for Expr {
                         write!(f, "{} is greater than or equal to {}", b.lhs, b.rhs)
                     }
                     crate::token::Op::GetI => write!(f, "GetI"),
+                    crate::token::Op::Cons => write!(f, "Cons"),
                 },
                 _ => unreachable!(),
             },

--- a/src/token.rs
+++ b/src/token.rs
@@ -65,6 +65,7 @@ pub enum Ctrl {
     Newline,
     LeftBracket,
     RightBracket,
+    Comma,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -112,7 +113,8 @@ impl std::fmt::Display for TokenType {
                 Ctrl::RightParen => write!(f, "Control<RightParen>"),
                 Ctrl::Newline => write!(f, "Control<Newline>"),
                 Ctrl::LeftBracket => write!(f, "Control<LeftBracket>"),
-                Ctrl::RightBracket => write!(f, "Control<RightBracket"),
+                Ctrl::RightBracket => write!(f, "Control<RightBracket>"),
+                Ctrl::Comma => write!(f, "Control<Comma>"),
             },
             TokenType::Keyword(k) => match k {
                 Kwd::If => write!(f, "Keyword<If>"),

--- a/src/token.rs
+++ b/src/token.rs
@@ -54,6 +54,7 @@ pub enum Op {
     Equality,
     LessEqual,
     GreaterEqual,
+    GetI,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -105,6 +106,7 @@ impl std::fmt::Display for TokenType {
                 Op::Equality => write!(f, "Operator<Equality>"),
                 Op::LessEqual => write!(f, "Operator<LessThanOrEqual>"),
                 Op::GreaterEqual => write!(f, "Operator<GreaterThanOrEqual"),
+                Op::GetI => write!(f, "Operator<GetI>"),
             },
             TokenType::Control(c) => match c {
                 Ctrl::Semicolon => write!(f, "Control<Semicolon>"),

--- a/src/token.rs
+++ b/src/token.rs
@@ -63,6 +63,8 @@ pub enum Ctrl {
     LeftParen,
     RightParen,
     Newline,
+    LeftBracket,
+    RightBracket,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -109,6 +111,8 @@ impl std::fmt::Display for TokenType {
                 Ctrl::LeftParen => write!(f, "Control<LeftParen>"),
                 Ctrl::RightParen => write!(f, "Control<RightParen>"),
                 Ctrl::Newline => write!(f, "Control<Newline>"),
+                Ctrl::LeftBracket => write!(f, "Control<LeftBracket>"),
+                Ctrl::RightBracket => write!(f, "Control<RightBracket"),
             },
             TokenType::Keyword(k) => match k {
                 Kwd::If => write!(f, "Keyword<If>"),

--- a/src/token.rs
+++ b/src/token.rs
@@ -55,6 +55,7 @@ pub enum Op {
     LessEqual,
     GreaterEqual,
     GetI,
+    Cons,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -107,6 +108,7 @@ impl std::fmt::Display for TokenType {
                 Op::LessEqual => write!(f, "Operator<LessThanOrEqual>"),
                 Op::GreaterEqual => write!(f, "Operator<GreaterThanOrEqual"),
                 Op::GetI => write!(f, "Operator<GetI>"),
+                Op::Cons => write!(f, "Operator<Cons>"),
             },
             TokenType::Control(c) => match c {
                 Ctrl::Semicolon => write!(f, "Control<Semicolon>"),

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -240,6 +240,32 @@ impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
                         })
                     }
                 }
+                crate::token::Op::Cons => {
+                    if left.check(&FerryType::List) {
+                        if right.check(&FerryType::List) {
+                            Ok(Expr::Binary(Binary {
+                                lhs: Box::new(left.clone()),
+                                operator: binary.operator.clone(),
+                                rhs: Box::new(right.clone()),
+                                expr_type: FerryTyping::Inferred(FerryType::List),
+                            }))
+                        } else {
+                            Err(FerryTypeError::TypeMismatch {
+                                advice: "invalid attempt at list cons".into(),
+                                span: *binary.operator.get_span(),
+                                lhs_span: *left.get_token().get_span(),
+                                rhs_span: *right.get_token().get_span(),
+                            })
+                        }
+                    } else {
+                        Err(FerryTypeError::TypeMismatch {
+                            advice: "invalid attempt at list cons".into(),
+                            span: *binary.operator.get_span(),
+                            lhs_span: *left.get_token().get_span(),
+                            rhs_span: *right.get_token().get_span(),
+                        })
+                    }
+                }
                 _ => Err(FerryTypeError::A {
                     advice: "aaa".into(),
                     span: *binary.operator.get_span(),

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -7,6 +7,7 @@ use crate::{
         walk_expr, Assign, Binary, Binding, Expr, ExprVisitor, Group, If, Lit, Loop, Unary,
         Variable,
     },
+    token::{Op, TokenType},
     types::{FerryType, FerryTyping, TypeCheckable, Typing},
 };
 
@@ -170,12 +171,8 @@ impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
         let right = self.check_types(&mut binary.rhs, state)?;
 
         match binary.operator.get_token_type() {
-            crate::token::TokenType::Operator(o) => match o {
-                crate::token::Op::Add
-                | crate::token::Op::Subtract
-                | crate::token::Op::Multiply
-                | crate::token::Op::Divide
-                | crate::token::Op::Equals => {
+            TokenType::Operator(o) => match o {
+                Op::Add | Op::Subtract | Op::Multiply | Op::Divide | Op::Equals => {
                     if left.check(right.get_type()) {
                         let expr_type = FerryTyping::Inferred(left.get_type().clone());
                         Ok(Expr::Binary(Binary {
@@ -193,11 +190,11 @@ impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
                         })
                     }
                 }
-                crate::token::Op::LessThan
-                | crate::token::Op::GreaterThan
-                | crate::token::Op::Equality
-                | crate::token::Op::LessEqual
-                | crate::token::Op::GreaterEqual => {
+                Op::LessThan
+                | Op::GreaterThan
+                | Op::Equality
+                | Op::LessEqual
+                | Op::GreaterEqual => {
                     if left.check(right.get_type()) {
                         Ok(Expr::Binary(Binary {
                             lhs: Box::new(left.clone()),
@@ -214,7 +211,7 @@ impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
                         })
                     }
                 }
-                crate::token::Op::GetI => {
+                Op::GetI => {
                     if left.check(&FerryType::List) {
                         if right.check(&FerryType::Num) {
                             Ok(Expr::Binary(Binary {
@@ -240,7 +237,7 @@ impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
                         })
                     }
                 }
-                crate::token::Op::Cons => {
+                Op::Cons => {
                     if left.check(&FerryType::List) {
                         if right.check(&FerryType::List) {
                             Ok(Expr::Binary(Binary {

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -273,7 +273,7 @@ impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
             },
             _ => Err(FerryTypeError::A {
                 advice: "aaa".into(),
-                span: binary.operator.get_span().clone(),
+                span: *binary.operator.get_span(),
             }),
         }
     }

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -143,6 +143,17 @@ impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
                 token: token.clone(),
                 expr_type: FerryTyping::Undefined,
             })),
+            Lit::List {
+                token,
+                contents,
+                expr_type: _,
+                span,
+            } => Ok(Expr::Literal(Lit::List {
+                token: token.clone(),
+                contents: contents.clone(),
+                expr_type: FerryTyping::Inferred(FerryType::List),
+                span: *span,
+            })),
         }
     }
 

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -101,7 +101,7 @@ impl FerryTypechecker {
 }
 
 impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
-    fn visit_literal(&mut self, literal: &mut Lit, _state: &mut FerryState) -> FerryResult<Expr> {
+    fn visit_literal(&mut self, literal: &mut Lit, state: &mut FerryState) -> FerryResult<Expr> {
         match literal {
             Lit::Number {
                 value,
@@ -148,12 +148,19 @@ impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
                 contents,
                 expr_type: _,
                 span,
-            } => Ok(Expr::Literal(Lit::List {
-                token: token.clone(),
-                contents: contents.clone(),
-                expr_type: FerryTyping::Inferred(FerryType::List),
-                span: *span,
-            })),
+            } => {
+                let mut checked_contents: Vec<Expr> = Vec::new();
+                for item in contents {
+                    checked_contents.push(self.check_types(item, state)?);
+                }
+
+                Ok(Expr::Literal(Lit::List {
+                    token: token.clone(),
+                    contents: checked_contents,
+                    expr_type: FerryTyping::Inferred(FerryType::List),
+                    span: *span,
+                }))
+            }
         }
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -15,6 +15,7 @@ pub enum FerryType {
     Num,
     String,
     Boolean,
+    List,
 }
 
 pub trait Typing {
@@ -106,6 +107,7 @@ impl std::fmt::Display for FerryType {
             FerryType::Num => write!(f, "Num"),
             FerryType::String => write!(f, "String"),
             FerryType::Boolean => write!(f, "Boolean"),
+            FerryType::List => write!(f, "List"),
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -75,6 +75,12 @@ impl Typing for Expr {
                     expr_type,
                     token: _,
                 } => expr_type.get_type(),
+                Lit::List {
+                    token: _,
+                    contents: _,
+                    expr_type,
+                    span: _,
+                } => expr_type.get_type(),
             },
             Expr::Binary(b) => b.expr_type.get_type(),
             Expr::Variable(v) => v.expr_type.get_type(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -89,6 +89,7 @@ impl Typing for Expr {
             Expr::Group(g) => g.expr_type.get_type(),
             Expr::Binding(b) => b.expr_type.get_type(),
             Expr::Loop(l) => l.expr_type.get_type(),
+            Expr::Unary(u) => u.expr_type.get_type(),
         }
     }
 }


### PR DESCRIPTION
Closes #2 by adding lists functionality to the language.

# LISTS

Lists are delineated by [] and use comma-separated exprs to denote their contents.

`[10, 11]`
`[18 + 32, 100 / 5]`

# LIMITATIONS

This PR merely adds the availability of lists as an allowed element. Known limitations are currently:

- Cannot access elements in a list
- Cannot perform any operations on a list
- No `cons`-like operator to concat lists