### PR TITLE
improve string display in output

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -81,7 +81,7 @@ impl std::fmt::Display for FerryValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             FerryValue::Number(n) => write!(f, "{}", n),
-            FerryValue::Str(s) => write!(f, "{s}"),
+            FerryValue::Str(s) => write!(f, "\"{s}\""),
             FerryValue::Boolean(b) => write!(f, "{b}"),
             FerryValue::Unit => write!(f, "[unit]"),
         }


### PR DESCRIPTION
add `"` around strings in current output formatting (current output formatting is not `stdout` so should reflect internal type state and not output format)