### PR TITLE
for loop implementation

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -138,7 +138,7 @@ impl<'source> FerryLexer<'source> {
                     "do" => Some(TT::Keyword(Kwd::Do)),
                     "while" => Some(TT::Keyword(Kwd::While)),
                     "for" => Some(TT::Keyword(Kwd::For)),
-
+                    "in" => Some(TT::Keyword(Kwd::In)),
                     // reserved boolean keywords
                     "true" => Some(TT::Value(Val::Boolean(true))),
                     "false" => Some(TT::Value(Val::Boolean(false))),
@@ -252,6 +252,23 @@ impl<'source> FerryLexer<'source> {
             while self.peek().is_ascii_digit() {
                 self.advance();
             }
+        } else if self.peek() == b'.' && self.peek_next() == b'.' {
+            // consume the .. token
+            let start = self
+                .substring(self.start, self.current)?
+                .parse::<i64>()
+                .expect("should have been i64");
+            self.advance();
+            self.advance();
+            let end_start = self.current;
+            while self.peek().is_ascii_digit() {
+                self.advance();
+            }
+            let end = self
+                .substring(end_start, self.current)?
+                .parse::<i64>()
+                .expect("should have been i64");
+            return Ok(TokenType::Value(Val::Range(start, end)));
         }
 
         Ok(TokenType::Value(Val::Num(

--- a/src/riscv.rs
+++ b/src/riscv.rs
@@ -242,6 +242,14 @@ impl ExprVisitor<FerryResult<Instruction>, &mut Vec<Instruction>> for &mut Ferry
     ) -> FerryResult<Instruction> {
         todo!()
     }
+
+    fn visit_for(
+        &mut self,
+        for_expr: &mut crate::syntax::For,
+        state: &mut Vec<Instruction>,
+    ) -> FerryResult<Instruction> {
+        todo!()
+    }
 }
 
 /// `Instruction`

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,3 +1,4 @@
+use clap::Id;
 use miette::SourceSpan;
 
 /// `Token`
@@ -21,6 +22,14 @@ impl FerryToken {
     pub fn get_span(&self) -> &SourceSpan {
         &self.span
     }
+
+    pub fn get_id(&self) -> Option<String> {
+        if let TokenType::Identifier(id) = &self.token_type {
+            Some(id.clone())
+        } else {
+            None
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -39,6 +48,7 @@ pub enum Val {
     Num(f64),
     String(String),
     Boolean(bool),
+    Range(i64, i64),
     None,
 }
 
@@ -79,6 +89,7 @@ pub enum Kwd {
     Do,
     While,
     For,
+    In,
 }
 
 impl std::fmt::Display for FerryToken {
@@ -95,6 +106,7 @@ impl std::fmt::Display for TokenType {
                 Val::String(s) => write!(f, "Value<String> {s}"),
                 Val::Boolean(b) => write!(f, "Value<Boolean> {b}"),
                 Val::None => write!(f, "Value<None>"),
+                Val::Range(s, e) => write!(f, "Value<Range> {s}..{e}"),
             },
             TokenType::Operator(o) => match o {
                 Op::Add => write!(f, "Operator<Add>"),
@@ -128,6 +140,7 @@ impl std::fmt::Display for TokenType {
                 Kwd::Do => write!(f, "Keyword<Do>"),
                 Kwd::While => write!(f, "Keyword<While>"),
                 Kwd::For => write!(f, "Keyword<For>"),
+                Kwd::In => write!(f, "Keyword<In>"),
             },
             TokenType::Identifier(i) => write!(f, "Identifier {i}"),
             TokenType::End => write!(f, "END"),

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -64,6 +64,13 @@ pub enum FerryTypeError {
         #[label]
         span: SourceSpan,
     },
+    #[error("invalid operand")]
+    InvalidOperand {
+        #[help]
+        advice: String,
+        #[label]
+        span: SourceSpan,
+    },
 }
 
 type FerryResult<T> = Result<T, FerryTypeError>;
@@ -263,13 +270,9 @@ impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
                         })
                     }
                 }
-                _ => Err(FerryTypeError::A {
-                    advice: "aaa 1".into(),
-                    span: *binary.operator.get_span(),
-                }),
             },
-            _ => Err(FerryTypeError::A {
-                advice: "aaa 2".into(),
+            _ => Err(FerryTypeError::InvalidOperand {
+                advice: "invalid operator token".into(),
                 span: *binary.operator.get_span(),
             }),
         }
@@ -392,8 +395,8 @@ impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
                             expr_type: FerryTyping::Untyped,
                         }));
                     } else {
-                        return Err(FerryTypeError::A {
-                            advice: "aaa 3".into(),
+                        return Err(FerryTypeError::MistypedVariable {
+                            advice: "cannot assign this value to this variable".into(),
                             span: *binding.token.get_span(),
                         });
                     }
@@ -417,8 +420,8 @@ impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
             }));
         }
 
-        Err(FerryTypeError::A {
-            advice: "aaa 4".into(),
+        Err(FerryTypeError::UnknownType {
+            advice: "unknown type for variable".into(),
             span: *binding.token.get_span(),
         })
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -90,6 +90,7 @@ impl Typing for Expr {
             Expr::Binding(b) => b.expr_type.get_type(),
             Expr::Loop(l) => l.expr_type.get_type(),
             Expr::Unary(u) => u.expr_type.get_type(),
+            Expr::For(f) => f.expr_type.get_type(),
         }
     }
 }


### PR DESCRIPTION
draft for loop implementation. currently does not respect type assignment in its syntax (the variable provided will take the type of the iterated `List`)

this PR also adds range operator to create an inclusive range with `..`.

# Syntax examples

## for loops

```
let a := 0
for v in [1, 2, 3]: a = a + v
a
```

## range operator

```
let a := 0
for v in 1..10: a = a + v
a
```