### PR TITLE
comments functional

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -98,9 +98,20 @@ impl<'source> FerryLexer<'source> {
                 // }
             }
             b'*' => Ok(Some(TT::Operator(Op::Multiply))),
-            b'/' => Ok(Some(TT::Operator(Op::Divide))),
+            b'/' => {
+                if self.peek() == b'/' {
+                    while self.peek() != b'\n' && !self.end_of_code() {
+                        self.current += 1;
+                    }
+                    let comment = self.substring(self.start + 2, self.current - 1)?;
+                    Ok(None)
+                } else {
+                    Ok(Some(TT::Operator(Op::Divide)))
+                }
+            }
             b'=' => {
                 if self.peek() == b'=' {
+                    self.current += 1;
                     Ok(Some(TT::Operator(Op::Equality)))
                 } else {
                     Ok(Some(TT::Operator(Op::Equals)))
@@ -108,6 +119,7 @@ impl<'source> FerryLexer<'source> {
             }
             b'<' => {
                 if self.peek() == b'=' {
+                    self.current += 1;
                     Ok(Some(TT::Operator(Op::LessEqual)))
                 } else {
                     Ok(Some(TT::Operator(Op::LessThan)))
@@ -115,6 +127,7 @@ impl<'source> FerryLexer<'source> {
             }
             b'>' => {
                 if self.peek() == b'=' {
+                    self.current += 1;
                     Ok(Some(TT::Operator(Op::GreaterEqual)))
                 } else {
                     Ok(Some(TT::Operator(Op::GreaterThan)))

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -372,8 +372,7 @@ impl FerryParser {
                         name: id.clone(),
                         expr_type: FerryTyping::Untyped,
                     }));
-                    let operator =
-                        FerryToken::new(TT::Operator(Op::GetI), *self.peek().get_span());
+                    let operator = FerryToken::new(TT::Operator(Op::GetI), *self.peek().get_span());
                     self.consume(&TT::Control(Ctrl::LeftBracket), "expected '[' for index ")?;
                     let rhs = Box::new(self.start(state)?);
                     self.consume(&TT::Control(Ctrl::RightBracket), "expected ']' after '['")?;
@@ -401,6 +400,7 @@ impl FerryParser {
                 }))
             }
             TT::Control(Ctrl::LeftBracket) => self.list(state),
+            // TT::Comment(_) => {}
             _ => {
                 println!("oops");
                 Err(FerryParseError::UnexpectedToken {

--- a/src/token.rs
+++ b/src/token.rs
@@ -31,6 +31,7 @@ pub enum TokenType {
     Control(Ctrl),
     Keyword(Kwd),
     Identifier(String),
+    Comment(String),
     End,
 }
 
@@ -131,6 +132,7 @@ impl std::fmt::Display for TokenType {
             },
             TokenType::Identifier(i) => write!(f, "Identifier {i}"),
             TokenType::End => write!(f, "END"),
+            TokenType::Comment(c) => write!(f, "Comment: {c}"),
         }
     }
 }


### PR DESCRIPTION
Comment functionality added.

# Usage

Comments are made C-style with `//`, eg.

```
let x:= 10
// x is a variable that has been assigned to 10
```

The basis for holding tokens as metadata is established but is not functional (read: I don't want to implement an AST node for comments)