### PR TITLE
type Int represented as i64 internally

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -262,7 +262,7 @@ impl ExprVisitor<FerryResult<FerryValue>, &mut FerryState> for &mut FerryInterpr
             state.add_symbol(&assign.name, value.clone());
             Ok(value)
         } else {
-            Ok(Some(FerryValue::Number(0.)))
+            Ok(Some(FerryValue::Number(0)))
         }
     }
 
@@ -303,7 +303,7 @@ impl ExprVisitor<FerryResult<FerryValue>, &mut FerryState> for &mut FerryInterpr
             state.add_symbol(&binding.name, value.clone());
             Ok(value)
         } else {
-            Ok(Some(FerryValue::Number(0.)))
+            Ok(Some(FerryValue::Number(0)))
         }
     }
 
@@ -443,7 +443,7 @@ impl ExprVisitor<FerryResult<FerryValue>, &mut FerryState> for &mut FerryInterpr
 impl FerryValue {
     fn truthiness(&self) -> bool {
         match self {
-            FerryValue::Number(n) => n > &0.,
+            FerryValue::Number(n) => n > &0,
             FerryValue::Str(s) => !s.is_empty(),
             FerryValue::Boolean(b) => *b,
             FerryValue::Unit => false,

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -262,10 +262,14 @@ impl<'source> FerryLexer<'source> {
         }
 
         if self.peek() == b'.' && self.peek_next().is_ascii_digit() {
-            self.advance();
-            while self.peek().is_ascii_digit() {
-                self.advance();
-            }
+            return Err(FerryLexError::NotANumber {
+                advice: "floats currently unsupported".into(),
+                bad_num: (self.start, self.current - self.start).into(),
+            });
+            // self.advance();
+            // while self.peek().is_ascii_digit() {
+            // self.advance();
+            // }
         } else if self.peek() == b'.' && self.peek_next() == b'.' {
             // consume the .. token
             let start = self
@@ -287,7 +291,7 @@ impl<'source> FerryLexer<'source> {
 
         Ok(TokenType::Value(Val::Num(
             self.substring(self.start, self.current)?
-                .parse::<f64>()
+                .parse::<i64>()
                 .expect("that was not an f64? how"),
         )))
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -513,7 +513,7 @@ impl FerryParser {
                     for i in *start..=*end {
                         contents.push(Expr::Literal(SLit::Number {
                             token: self.previous().clone(),
-                            value: i as f64,
+                            value: i,
                             expr_type: FerryTyping::Untyped,
                             span: *self.previous().get_span(),
                         }));

--- a/src/state.rs
+++ b/src/state.rs
@@ -13,7 +13,7 @@ pub struct FerryState {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum FerryValue {
-    Number(f64),
+    Number(i64),
     Str(String),
     Boolean(bool),
     List(Vec<FerryValue>),

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -27,7 +27,7 @@ pub enum Lit {
     },
     Number {
         token: FerryToken,
-        value: f64,
+        value: i64,
         expr_type: FerryTyping,
         span: SourceSpan,
     },

--- a/src/token.rs
+++ b/src/token.rs
@@ -45,7 +45,7 @@ pub enum TokenType {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Val {
-    Num(f64),
+    Num(i64),
     String(String),
     Boolean(bool),
     Range(i64, i64),

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -391,7 +391,7 @@ impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
                 if let Some(assigned_type) = &binding.assigned_type {
                     if assigned_type.check(value_check.get_type()) {
                         let placeholder_value = match value_check.get_type() {
-                            FerryType::Num => FerryValue::Number(0.0),
+                            FerryType::Num => FerryValue::Number(0),
                             FerryType::String => FerryValue::Str("".into()),
                             FerryType::Boolean => FerryValue::Boolean(false),
                             FerryType::List => FerryValue::List(vec![]),
@@ -413,7 +413,7 @@ impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
                     }
                 } else {
                     let placeholder_value = match value_check.get_type() {
-                        FerryType::Num => FerryValue::Number(0.0),
+                        FerryType::Num => FerryValue::Number(0),
                         FerryType::String => FerryValue::Str("".into()),
                         FerryType::Boolean => FerryValue::Boolean(false),
                         FerryType::List => FerryValue::List(vec![]),
@@ -431,7 +431,7 @@ impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
             }
         } else if let Some(assigned_type) = &binding.assigned_type {
             let placeholder_value = match assigned_type {
-                FerryType::Num => FerryValue::Number(0.0),
+                FerryType::Num => FerryValue::Number(0),
                 FerryType::String => FerryValue::Str("".into()),
                 FerryType::Boolean => FerryValue::Boolean(false),
                 FerryType::List => FerryValue::List(vec![]),
@@ -513,7 +513,7 @@ impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
             let variable_checked = self.check_types(variable, state)?;
             if let Expr::Variable(var) = &variable_checked {
                 let placeholder_value = match variable_checked.get_type() {
-                    FerryType::Num => FerryValue::Number(0.0),
+                    FerryType::Num => FerryValue::Number(0),
                     FerryType::String => FerryValue::Str("".into()),
                     FerryType::Boolean => FerryValue::Boolean(false),
                     FerryType::List => FerryValue::List(vec![]),


### PR DESCRIPTION
fixes #19 by changing the internal representation of `Num` to `i64`. this will be refactored further when floats are introduced