### PR TITLE
Visitor refactor

### DIFF
--- a/examples/euler1.feri
+++ b/examples/euler1.feri
@@ -2,7 +2,7 @@ import std
 
 let sum: Int = 0
 
-for n: Int in 1..10: 
+for n: Int in 1..1000: 
     if modulo(n, 3) == 0 then: 
         sum = sum + n
     else: (

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -52,7 +52,7 @@ impl FerryInterpreter {
     ) -> Result<Option<FerryValue>, Vec<FerryInterpreterError>> {
         let mut ret = None;
         let mut errors = vec![];
-        for code in typed_ast.clone().iter() {
+        for code in typed_ast.iter() {
             match self.evaluate(code, state) {
                 Ok(r) => ret = r,
                 Err(e) => errors.push(e),
@@ -103,7 +103,7 @@ impl ExprVisitor<FerryResult<FerryValue>, &mut FerryState> for &mut FerryInterpr
             } => {
                 let mut values: Vec<FerryValue> = Vec::new();
                 for c in contents {
-                    if let Some(value) = self.evaluate(&c, state)? {
+                    if let Some(value) = self.evaluate(c, state)? {
                         values.push(value);
                     } else {
                         values.push(FerryValue::Unit);
@@ -413,12 +413,12 @@ impl ExprVisitor<FerryResult<FerryValue>, &mut FerryState> for &mut FerryInterpr
                             param_state.add_symbol(&var.name, arg_val);
                         }
                     }
-                    self.evaluate(&mut function.contents, &mut param_state)
+                    self.evaluate(&function.contents, &mut param_state)
                 } else {
-                    self.evaluate(&mut function.contents, &mut state.clone())
+                    self.evaluate(&function.contents, &mut state.clone())
                 }
             } else {
-                self.evaluate(&mut function.contents, &mut state.clone())
+                self.evaluate(&function.contents, &mut state.clone())
             }
         } else {
             Err(FerryInterpreterError::InvalidOperation {

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -37,23 +37,22 @@ pub enum FerryInterpreterError {
 type FerryResult<T> = Result<Option<T>, FerryInterpreterError>;
 
 #[allow(dead_code)]
-pub struct FerryInterpreter {
-    syntax: Vec<Expr>,
-}
+pub struct FerryInterpreter;
 
 #[allow(dead_code)]
 impl FerryInterpreter {
-    pub fn new(syntax: Vec<Expr>) -> Self {
-        Self { syntax }
+    pub fn new() -> Self {
+        Self {}
     }
 
     pub fn interpret(
         &mut self,
+        typed_ast: &[Expr],
         state: &mut FerryState,
     ) -> Result<Option<FerryValue>, Vec<FerryInterpreterError>> {
         let mut ret = None;
         let mut errors = vec![];
-        for code in self.syntax.clone().iter_mut() {
+        for code in typed_ast.clone().iter() {
             match self.evaluate(code, state) {
                 Ok(r) => ret = r,
                 Err(e) => errors.push(e),
@@ -66,17 +65,13 @@ impl FerryInterpreter {
         }
     }
 
-    fn evaluate(&mut self, code: &mut Expr, state: &mut FerryState) -> FerryResult<FerryValue> {
+    fn evaluate(&mut self, code: &Expr, state: &mut FerryState) -> FerryResult<FerryValue> {
         walk_expr(&mut *self, code, state)
     }
 }
 
 impl ExprVisitor<FerryResult<FerryValue>, &mut FerryState> for &mut FerryInterpreter {
-    fn visit_literal(
-        &mut self,
-        literal: &mut SLit,
-        state: &mut FerryState,
-    ) -> FerryResult<FerryValue> {
+    fn visit_literal(&mut self, literal: &SLit, state: &mut FerryState) -> FerryResult<FerryValue> {
         match literal {
             SLit::Number {
                 value,
@@ -108,7 +103,7 @@ impl ExprVisitor<FerryResult<FerryValue>, &mut FerryState> for &mut FerryInterpr
             } => {
                 let mut values: Vec<FerryValue> = Vec::new();
                 for c in contents {
-                    if let Some(value) = self.evaluate(c, state)? {
+                    if let Some(value) = self.evaluate(&c, state)? {
                         values.push(value);
                     } else {
                         values.push(FerryValue::Unit);
@@ -119,13 +114,9 @@ impl ExprVisitor<FerryResult<FerryValue>, &mut FerryState> for &mut FerryInterpr
         }
     }
 
-    fn visit_binary(
-        &mut self,
-        binary: &mut Binary,
-        state: &mut FerryState,
-    ) -> FerryResult<FerryValue> {
-        let left = self.evaluate(&mut binary.lhs, state)?;
-        let right = self.evaluate(&mut binary.rhs, state)?;
+    fn visit_binary(&mut self, binary: &Binary, state: &mut FerryState) -> FerryResult<FerryValue> {
+        let left = self.evaluate(&binary.lhs, state)?;
+        let right = self.evaluate(&binary.rhs, state)?;
 
         let op = &binary.operator;
 
@@ -254,18 +245,14 @@ impl ExprVisitor<FerryResult<FerryValue>, &mut FerryState> for &mut FerryInterpr
 
     fn visit_variable(
         &mut self,
-        variable: &mut Variable,
+        variable: &Variable,
         state: &mut FerryState,
     ) -> FerryResult<FerryValue> {
         Ok(state.get_symbol_value(&variable.name))
     }
 
-    fn visit_assign(
-        &mut self,
-        assign: &mut Assign,
-        state: &mut FerryState,
-    ) -> FerryResult<FerryValue> {
-        if let Some(v) = &mut assign.value {
+    fn visit_assign(&mut self, assign: &Assign, state: &mut FerryState) -> FerryResult<FerryValue> {
+        if let Some(v) = &assign.value {
             let value = self.evaluate(v, state).unwrap();
             state.add_symbol(&assign.name, value.clone());
             Ok(value)
@@ -274,15 +261,11 @@ impl ExprVisitor<FerryResult<FerryValue>, &mut FerryState> for &mut FerryInterpr
         }
     }
 
-    fn visit_if_expr(
-        &mut self,
-        if_expr: &mut If,
-        state: &mut FerryState,
-    ) -> FerryResult<FerryValue> {
-        if let Some(conditional) = self.evaluate(&mut if_expr.condition, state)? {
+    fn visit_if_expr(&mut self, if_expr: &If, state: &mut FerryState) -> FerryResult<FerryValue> {
+        if let Some(conditional) = self.evaluate(&if_expr.condition, state)? {
             let value = if conditional.truthiness() {
-                self.evaluate(&mut if_expr.then_expr, state)?
-            } else if let Some(else_expr) = &mut if_expr.else_expr {
+                self.evaluate(&if_expr.then_expr, state)?
+            } else if let Some(else_expr) = &if_expr.else_expr {
                 self.evaluate(else_expr, state)?
             } else {
                 None
@@ -293,20 +276,16 @@ impl ExprVisitor<FerryResult<FerryValue>, &mut FerryState> for &mut FerryInterpr
         }
     }
 
-    fn visit_group(
-        &mut self,
-        group: &mut Group,
-        state: &mut FerryState,
-    ) -> FerryResult<FerryValue> {
-        self.evaluate(&mut group.contents, state)
+    fn visit_group(&mut self, group: &Group, state: &mut FerryState) -> FerryResult<FerryValue> {
+        self.evaluate(&group.contents, state)
     }
 
     fn visit_binding(
         &mut self,
-        binding: &mut Binding,
+        binding: &Binding,
         state: &mut FerryState,
     ) -> FerryResult<FerryValue> {
-        if let Some(v) = &mut binding.value {
+        if let Some(v) = &binding.value {
             let value = self.evaluate(v, state)?;
             state.add_symbol(&binding.name, value.clone());
             Ok(value)
@@ -315,17 +294,13 @@ impl ExprVisitor<FerryResult<FerryValue>, &mut FerryState> for &mut FerryInterpr
         }
     }
 
-    fn visit_loop(
-        &mut self,
-        loop_expr: &mut Loop,
-        state: &mut FerryState,
-    ) -> FerryResult<FerryValue> {
-        if let Some(cond) = &mut loop_expr.condition {
+    fn visit_loop(&mut self, loop_expr: &Loop, state: &mut FerryState) -> FerryResult<FerryValue> {
+        if let Some(cond) = &loop_expr.condition {
             match self.evaluate(cond, state)? {
                 Some(b) => {
                     if b.truthiness() {
                         loop {
-                            self.evaluate(&mut loop_expr.contents.clone(), state)?;
+                            self.evaluate(&loop_expr.contents.clone(), state)?;
                             if let Ok(Some(b)) = self.evaluate(cond, state) {
                                 if !b.truthiness() {
                                     break;
@@ -344,19 +319,15 @@ impl ExprVisitor<FerryResult<FerryValue>, &mut FerryState> for &mut FerryInterpr
         } else {
             println!("{:?}", loop_expr.contents);
             loop {
-                if let Some(res) = self.evaluate(&mut loop_expr.contents, state)? {
+                if let Some(res) = self.evaluate(&loop_expr.contents, state)? {
                     println!("{res}")
                 }
             }
         }
     }
 
-    fn visit_unary(
-        &mut self,
-        unary: &mut Unary,
-        state: &mut FerryState,
-    ) -> FerryResult<FerryValue> {
-        let _right = self.evaluate(&mut unary.rhs, state)?;
+    fn visit_unary(&mut self, unary: &Unary, state: &mut FerryState) -> FerryResult<FerryValue> {
+        let _right = self.evaluate(&unary.rhs, state)?;
 
         #[expect(clippy::match_single_binding)]
         match unary.operator.get_token_type() {
@@ -367,16 +338,16 @@ impl ExprVisitor<FerryResult<FerryValue>, &mut FerryState> for &mut FerryInterpr
         }
     }
 
-    fn visit_for(&mut self, for_expr: &mut For, state: &mut FerryState) -> FerryResult<FerryValue> {
-        if let Some(variable) = &mut for_expr.variable {
+    fn visit_for(&mut self, for_expr: &For, state: &mut FerryState) -> FerryResult<FerryValue> {
+        if let Some(variable) = &for_expr.variable {
             let name = variable.get_token().get_id().unwrap_or("error".into());
-            let iterator = self.evaluate(&mut for_expr.iterator, state)?;
+            let iterator = self.evaluate(&for_expr.iterator, state)?;
             if let Some(value) = iterator {
                 match value {
                     FerryValue::List(list) => {
                         for l in list {
                             state.add_symbol(&name, Some(l));
-                            self.evaluate(&mut for_expr.contents, state)?;
+                            self.evaluate(&for_expr.contents, state)?;
                         }
                         Ok(None)
                     }
@@ -401,7 +372,7 @@ impl ExprVisitor<FerryResult<FerryValue>, &mut FerryState> for &mut FerryInterpr
 
     fn visit_function(
         &mut self,
-        function: &mut Function,
+        function: &Function,
         state: &mut FerryState,
     ) -> FerryResult<FerryValue> {
         let name = function.name.clone();
@@ -424,7 +395,7 @@ impl ExprVisitor<FerryResult<FerryValue>, &mut FerryState> for &mut FerryInterpr
         Ok(None)
     }
 
-    fn visit_call(&mut self, call: &mut Call, state: &mut FerryState) -> FerryResult<FerryValue> {
+    fn visit_call(&mut self, call: &Call, state: &mut FerryState) -> FerryResult<FerryValue> {
         if let Some(FerryValue::Function(FuncVal {
             declaration: Some(function),
             name: _,
@@ -436,7 +407,7 @@ impl ExprVisitor<FerryResult<FerryValue>, &mut FerryState> for &mut FerryInterpr
             if let Some(params) = &mut function.args {
                 if !call.args.is_empty() {
                     let mut param_state = state.clone();
-                    for (arg, param_var) in call.args.iter_mut().zip(params.iter_mut()) {
+                    for (arg, param_var) in call.args.iter().zip(params.iter()) {
                         if let Expr::Binding(var) = param_var {
                             let arg_val = self.evaluate(arg, state)?;
                             param_state.add_symbol(&var.name, arg_val);
@@ -459,7 +430,7 @@ impl ExprVisitor<FerryResult<FerryValue>, &mut FerryState> for &mut FerryInterpr
 
     fn visit_module(
         &mut self,
-        _module: &mut Module,
+        _module: &Module,
         _state: &mut FerryState,
     ) -> FerryResult<FerryValue> {
         todo!()
@@ -467,7 +438,7 @@ impl ExprVisitor<FerryResult<FerryValue>, &mut FerryState> for &mut FerryInterpr
 
     fn visit_import(
         &mut self,
-        _import: &mut Import,
+        _import: &Import,
         _state: &mut FerryState,
     ) -> FerryResult<FerryValue> {
         todo!()

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -58,7 +58,7 @@ impl FerryIr {
                 }
             } else if let Expr::Module(module) = expr {
                 for function in module.functions.clone() {
-                    match self.assemble_opcode(&mut Expr::Function(function), state) {
+                    match self.assemble_opcode(&Expr::Function(function), state) {
                         Ok(mut instructions) => functions.append(&mut instructions),
                         Err(e) => println!("{e}"),
                     }
@@ -551,7 +551,7 @@ impl ExprVisitor<FerryResult<Vec<FerryOpcode>>, &mut FerryState> for &mut FerryI
         let instructions = vec![];
 
         for function in import.functions.clone() {
-            self.assemble_opcode(&mut Expr::Function(function), state)?;
+            self.assemble_opcode(&Expr::Function(function), state)?;
         }
 
         Ok(instructions)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,19 +75,18 @@ impl Ferry {
 
         self.ast = ast.clone();
 
-        let mut typechecker = FerryTypechecker::new(ast);
-        let typed_ast =
-            typechecker
-                .typecheck(&mut self.state)
-                .map_err(|err_list| FerryTypeErrors {
-                    source_code: String::from_utf8(self.source_code.as_bytes().to_vec()).unwrap(),
-                    related: err_list,
-                })?;
+        let mut typechecker = FerryTypechecker::new();
+        let typed_ast = typechecker
+            .typecheck(&ast, &mut self.state)
+            .map_err(|err_list| FerryTypeErrors {
+                source_code: String::from_utf8(self.source_code.as_bytes().to_vec()).unwrap(),
+                related: err_list,
+            })?;
 
         self.typed_ast = typed_ast.clone();
 
-        let mut ir = FerryIr::new(typed_ast);
-        let ferry_ir = ir.lower(&mut self.state).unwrap();
+        let mut ir = FerryIr::new();
+        let ferry_ir = ir.lower(&typed_ast, &mut self.state).unwrap();
         self.ferry_ir = ferry_ir.clone();
 
         // self.vm.set_program(self.ferry_ir.clone());

--- a/src/parser/syntax.rs
+++ b/src/parser/syntax.rs
@@ -162,23 +162,23 @@ pub struct Import {
 }
 
 pub trait ExprVisitor<T, S> {
-    fn visit_literal(&mut self, literal: &mut Lit, state: S) -> T;
-    fn visit_binary(&mut self, binary: &mut Binary, state: S) -> T;
-    fn visit_unary(&mut self, unary: &mut Unary, state: S) -> T;
-    fn visit_variable(&mut self, variable: &mut Variable, state: S) -> T;
-    fn visit_assign(&mut self, assign: &mut Assign, state: S) -> T;
-    fn visit_if_expr(&mut self, if_expr: &mut If, state: S) -> T;
-    fn visit_group(&mut self, group: &mut Group, state: S) -> T;
-    fn visit_binding(&mut self, binding: &mut Binding, state: S) -> T;
-    fn visit_loop(&mut self, loop_expr: &mut Loop, state: S) -> T;
-    fn visit_for(&mut self, for_expr: &mut For, state: S) -> T;
-    fn visit_function(&mut self, function: &mut Function, state: S) -> T;
-    fn visit_call(&mut self, call: &mut Call, state: S) -> T;
-    fn visit_module(&mut self, module: &mut Module, state: S) -> T;
-    fn visit_import(&mut self, import: &mut Import, state: S) -> T;
+    fn visit_literal(&mut self, literal: &Lit, state: S) -> T;
+    fn visit_binary(&mut self, binary: &Binary, state: S) -> T;
+    fn visit_unary(&mut self, unary: &Unary, state: S) -> T;
+    fn visit_variable(&mut self, variable: &Variable, state: S) -> T;
+    fn visit_assign(&mut self, assign: &Assign, state: S) -> T;
+    fn visit_if_expr(&mut self, if_expr: &If, state: S) -> T;
+    fn visit_group(&mut self, group: &Group, state: S) -> T;
+    fn visit_binding(&mut self, binding: &Binding, state: S) -> T;
+    fn visit_loop(&mut self, loop_expr: &Loop, state: S) -> T;
+    fn visit_for(&mut self, for_expr: &For, state: S) -> T;
+    fn visit_function(&mut self, function: &Function, state: S) -> T;
+    fn visit_call(&mut self, call: &Call, state: S) -> T;
+    fn visit_module(&mut self, module: &Module, state: S) -> T;
+    fn visit_import(&mut self, import: &Import, state: S) -> T;
 }
 
-pub fn walk_expr<T, S>(mut visitor: impl ExprVisitor<T, S>, expr: &mut Expr, state: S) -> T {
+pub fn walk_expr<T, S>(mut visitor: impl ExprVisitor<T, S>, expr: &Expr, state: S) -> T {
     match expr {
         Expr::Literal(literal) => visitor.visit_literal(literal, state),
         Expr::Binary(binary) => visitor.visit_binary(binary, state),

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -908,7 +908,7 @@ impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
 
         for function in module.functions.clone() {
             if let Expr::Function(checked_function) =
-                self.check_types(&mut Expr::Function(function), state)?
+                self.check_types(&Expr::Function(function), state)?
             {
                 checked_fns.push(checked_function);
             } else {
@@ -931,7 +931,7 @@ impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
 
         for function in import.functions.clone() {
             if let Expr::Function(checked_function) =
-                self.check_types(&mut Expr::Function(function), state)?
+                self.check_types(&Expr::Function(function), state)?
             {
                 checked_fns.push(checked_function);
             } else {

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -82,20 +82,22 @@ type FerryResult<T> = Result<T, FerryTypeError>;
 type FerryTypecheckResult<T> = Result<Vec<T>, Vec<FerryTypeError>>;
 
 #[derive(Debug)]
-pub struct FerryTypechecker {
-    syntax: Vec<Expr>,
-}
+pub struct FerryTypechecker;
 
 impl FerryTypechecker {
-    pub fn new(syntax: Vec<Expr>) -> Self {
-        Self { syntax }
+    pub fn new() -> Self {
+        Self {}
     }
 
-    pub fn typecheck(&mut self, state: &mut FerryState) -> FerryTypecheckResult<Expr> {
+    pub fn typecheck(
+        &mut self,
+        syntax: &[Expr],
+        state: &mut FerryState,
+    ) -> FerryTypecheckResult<Expr> {
         let mut result = Vec::new();
         let mut errors = Vec::new();
 
-        for code in self.syntax.clone().iter_mut() {
+        for code in syntax.iter() {
             match self.check_types(code, state) {
                 Ok(r) => result.push(r),
                 Err(e) => errors.push(e),
@@ -109,13 +111,13 @@ impl FerryTypechecker {
         }
     }
 
-    fn check_types(&mut self, code: &mut Expr, state: &mut FerryState) -> FerryResult<Expr> {
-        walk_expr(&mut *self, code, state)
+    fn check_types(&mut self, code: &Expr, state: &mut FerryState) -> FerryResult<Expr> {
+        walk_expr(self, code, state)
     }
 
     fn infer(
         &mut self,
-        code: &mut Expr,
+        code: &Expr,
         state: &mut FerryState,
         infer_type: FerryType,
     ) -> FerryResult<Expr> {
@@ -261,7 +263,7 @@ fn set_type(expr_type: FerryTyping, infer_type: FerryType) -> FerryTyping {
 }
 
 impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
-    fn visit_literal(&mut self, literal: &mut Lit, state: &mut FerryState) -> FerryResult<Expr> {
+    fn visit_literal(&mut self, literal: &Lit, state: &mut FerryState) -> FerryResult<Expr> {
         match literal {
             Lit::Number {
                 value,
@@ -324,12 +326,12 @@ impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
         }
     }
 
-    fn visit_binary(&mut self, binary: &mut Binary, state: &mut FerryState) -> FerryResult<Expr> {
+    fn visit_binary(&mut self, binary: &Binary, state: &mut FerryState) -> FerryResult<Expr> {
         match binary.operator.get_token_type() {
             TokenType::Operator(o) => match o {
                 Op::Add | Op::Subtract | Op::Multiply | Op::Divide | Op::Equals => {
-                    let left = self.infer(&mut binary.lhs, state, FerryType::Num)?;
-                    let right = self.infer(&mut binary.rhs, state, FerryType::Num)?;
+                    let left = self.infer(&binary.lhs, state, FerryType::Num)?;
+                    let right = self.infer(&binary.rhs, state, FerryType::Num)?;
                     if left.check(right.get_type()) {
                         let expr_type = FerryTyping::Inferred(left.get_type().clone());
                         Ok(Expr::Binary(Binary {
@@ -363,8 +365,8 @@ impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
                 | Op::Equality
                 | Op::LessEqual
                 | Op::GreaterEqual => {
-                    let left = self.infer(&mut binary.lhs, state, FerryType::Num)?;
-                    let right = self.infer(&mut binary.rhs, state, FerryType::Num)?;
+                    let left = self.infer(&binary.lhs, state, FerryType::Num)?;
+                    let right = self.infer(&binary.rhs, state, FerryType::Num)?;
                     if left.check(right.get_type()) {
                         Ok(Expr::Binary(Binary {
                             lhs: Box::new(left.clone()),
@@ -382,8 +384,8 @@ impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
                     }
                 }
                 Op::GetI => {
-                    let left = self.infer(&mut binary.lhs, state, FerryType::List)?;
-                    let right = self.infer(&mut binary.rhs, state, FerryType::Num)?;
+                    let left = self.infer(&binary.lhs, state, FerryType::List)?;
+                    let right = self.infer(&binary.rhs, state, FerryType::Num)?;
                     if left.check(&FerryType::List) {
                         if right.check(&FerryType::Num) {
                             Ok(Expr::Binary(Binary {
@@ -410,8 +412,8 @@ impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
                     }
                 }
                 Op::Cons => {
-                    let left = self.infer(&mut binary.lhs, state, FerryType::List)?;
-                    let right = self.infer(&mut binary.rhs, state, FerryType::List)?;
+                    let left = self.infer(&binary.lhs, state, FerryType::List)?;
+                    let right = self.infer(&binary.rhs, state, FerryType::List)?;
                     if left.check(&FerryType::List) {
                         if right.check(&FerryType::List) {
                             Ok(Expr::Binary(Binary {
@@ -445,11 +447,7 @@ impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
         }
     }
 
-    fn visit_variable(
-        &mut self,
-        variable: &mut Variable,
-        state: &mut FerryState,
-    ) -> FerryResult<Expr> {
+    fn visit_variable(&mut self, variable: &Variable, state: &mut FerryState) -> FerryResult<Expr> {
         // we expect that the variable has been declared in some scope prior to being referenced
         if let (Some(derived_type), assigned_type) =
             (state.get_symbol_value(&variable.name), &variable.expr_type)
@@ -482,9 +480,9 @@ impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
         }
     }
 
-    fn visit_assign(&mut self, assign: &mut Assign, state: &mut FerryState) -> FerryResult<Expr> {
+    fn visit_assign(&mut self, assign: &Assign, state: &mut FerryState) -> FerryResult<Expr> {
         // type inference first
-        if let Some(value) = &mut assign.value {
+        if let Some(value) = &assign.value {
             if let Ok(value_check) = self.infer(value, state, FerryType::Undefined) {
                 Ok(Expr::Assign(Assign {
                     var: assign.var.clone(),
@@ -513,16 +511,16 @@ impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
         }
     }
 
-    fn visit_if_expr(&mut self, if_expr: &mut If, state: &mut FerryState) -> FerryResult<Expr> {
-        let condition = self.check_types(&mut if_expr.condition, state)?;
+    fn visit_if_expr(&mut self, if_expr: &If, state: &mut FerryState) -> FerryResult<Expr> {
+        let condition = self.check_types(&if_expr.condition, state)?;
         if !condition.check(&FerryType::Boolean) {
             return Err(FerryTypeError::ConditionalNotBool {
                 advice: "expected conditional to if statement to be of type 'bool'".into(),
                 span: *if_expr.token.get_span(),
             });
         }
-        let then_expr = self.check_types(&mut if_expr.then_expr, state)?;
-        let else_expr = if let Some(else_expr_box) = &mut if_expr.else_expr {
+        let then_expr = self.check_types(&if_expr.then_expr, state)?;
+        let else_expr = if let Some(else_expr_box) = &if_expr.else_expr {
             let else_expr = self.check_types(else_expr_box, state)?;
             if then_expr.get_type() != else_expr.get_type() {
                 return Err(FerryTypeError::MismatchedThenElse {
@@ -547,8 +545,8 @@ impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
         }))
     }
 
-    fn visit_group(&mut self, group: &mut Group, state: &mut FerryState) -> FerryResult<Expr> {
-        let contents = Box::new(self.check_types(&mut group.contents, state)?);
+    fn visit_group(&mut self, group: &Group, state: &mut FerryState) -> FerryResult<Expr> {
+        let contents = Box::new(self.check_types(&group.contents, state)?);
         let expr_type = FerryTyping::Inferred(contents.get_type().clone());
 
         Ok(Expr::Group(Group {
@@ -558,13 +556,9 @@ impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
         }))
     }
 
-    fn visit_binding(
-        &mut self,
-        binding: &mut Binding,
-        state: &mut FerryState,
-    ) -> FerryResult<Expr> {
+    fn visit_binding(&mut self, binding: &Binding, state: &mut FerryState) -> FerryResult<Expr> {
         // type inference first
-        if let Some(value) = &mut binding.value {
+        if let Some(value) = &binding.value {
             if let Ok(value_check) = self.check_types(value, state) {
                 if let Some(assigned_type) = &binding.assigned_type {
                     if assigned_type.check(value_check.get_type()) {
@@ -646,11 +640,11 @@ impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
         })
     }
 
-    fn visit_loop(&mut self, loop_expr: &mut Loop, state: &mut FerryState) -> FerryResult<Expr> {
-        if let Some(cond) = &mut loop_expr.condition {
+    fn visit_loop(&mut self, loop_expr: &Loop, state: &mut FerryState) -> FerryResult<Expr> {
+        if let Some(cond) = &loop_expr.condition {
             let condition = Box::new(self.check_types(cond, state)?);
             if condition.check(&FerryType::Boolean) {
-                let contents = Box::new(self.check_types(&mut loop_expr.contents, state)?);
+                let contents = Box::new(self.check_types(&loop_expr.contents, state)?);
                 let expr_type = FerryTyping::Inferred(contents.get_type().clone());
                 Ok(Expr::Loop(Loop {
                     token: loop_expr.token.clone(),
@@ -665,7 +659,7 @@ impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
                 })
             }
         } else {
-            let contents = Box::new(self.check_types(&mut loop_expr.contents, state)?);
+            let contents = Box::new(self.check_types(&loop_expr.contents, state)?);
             let expr_type = FerryTyping::Inferred(contents.get_type().clone());
             Ok(Expr::Loop(Loop {
                 token: loop_expr.token.clone(),
@@ -676,8 +670,8 @@ impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
         }
     }
 
-    fn visit_unary(&mut self, unary: &mut Unary, state: &mut FerryState) -> FerryResult<Expr> {
-        let right = self.check_types(&mut unary.rhs, state)?;
+    fn visit_unary(&mut self, unary: &Unary, state: &mut FerryState) -> FerryResult<Expr> {
+        let right = self.check_types(&unary.rhs, state)?;
 
         if right.get_type() == &FerryType::Num {
             Ok(Expr::Unary(Unary {
@@ -695,9 +689,9 @@ impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
         }
     }
 
-    fn visit_for(&mut self, for_expr: &mut For, state: &mut FerryState) -> FerryResult<Expr> {
-        let iterator = self.check_types(&mut for_expr.iterator, state)?;
-        if let Some(variable) = &mut for_expr.variable {
+    fn visit_for(&mut self, for_expr: &For, state: &mut FerryState) -> FerryResult<Expr> {
+        let iterator = self.check_types(&for_expr.iterator, state)?;
+        if let Some(variable) = &for_expr.variable {
             if let Expr::Variable(v) = variable.as_ref() {
                 state.add_symbol(&v.name, None);
             }
@@ -721,7 +715,7 @@ impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
                 };
                 state.add_symbol(&var.name, Some(placeholder_value));
             }
-            let contents = self.check_types(&mut for_expr.contents, state)?;
+            let contents = self.check_types(&for_expr.contents, state)?;
 
             if iterator.get_type() == &FerryType::List {
                 let inf_type = contents.get_type().clone();
@@ -741,7 +735,7 @@ impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
                 })
             }
         } else {
-            let contents = self.check_types(&mut for_expr.contents, state)?;
+            let contents = self.check_types(&for_expr.contents, state)?;
             if iterator.get_type() == &FerryType::List {
                 let inf_type = contents.get_type().clone();
                 Ok(Expr::For(For {
@@ -761,11 +755,7 @@ impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
         }
     }
 
-    fn visit_function(
-        &mut self,
-        function: &mut Function,
-        state: &mut FerryState,
-    ) -> FerryResult<Expr> {
+    fn visit_function(&mut self, function: &Function, state: &mut FerryState) -> FerryResult<Expr> {
         // let expr_type = FerryTyping::Assigned(FerryType::Function);
         // Need to rework logic of functions in general to enable first-class functions
         let (expr_type, return_type) = if let Some(ty) = &function.return_type {
@@ -797,7 +787,7 @@ impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
         );
 
         let mut arity = 0;
-        let args = if let Some(arguments) = &mut function.args {
+        let args = if let Some(arguments) = &function.args {
             let mut rets = Vec::new();
             for a in arguments {
                 let arg = self.check_types(a, &mut fn_state)?;
@@ -809,7 +799,7 @@ impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
             None
         };
 
-        let checked_contents = Box::new(self.check_types(&mut function.contents, &mut fn_state)?);
+        let checked_contents = Box::new(self.check_types(&function.contents, &mut fn_state)?);
         // if checked_contents.get_type() != expr_type.get_type()
         //     && expr_type == FerryTyping::Inferred(FerryType::Undefined)
         // {
@@ -841,7 +831,7 @@ impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
         Ok(Expr::Function(function_checked))
     }
 
-    fn visit_call(&mut self, call: &mut Call, state: &mut FerryState) -> FerryResult<Expr> {
+    fn visit_call(&mut self, call: &Call, state: &mut FerryState) -> FerryResult<Expr> {
         // println!("state: {:?}", state);
         if let Some(FerryValue::Function(FuncVal {
             declaration: decl,
@@ -868,7 +858,7 @@ impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
                 }
                 if !call.args.is_empty() {
                     let mut checked_args = Vec::new();
-                    for (call_arg, decl_arg) in call.args.iter_mut().zip(decl_args.iter_mut()) {
+                    for (call_arg, decl_arg) in call.args.iter().zip(decl_args.iter()) {
                         let checked_arg = self.check_types(call_arg, state)?;
                         let checked_decl_arg = self.check_types(decl_arg, state)?;
                         if checked_arg.check(checked_decl_arg.get_type()) {
@@ -913,7 +903,7 @@ impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
         }
     }
 
-    fn visit_module(&mut self, module: &mut Module, state: &mut FerryState) -> FerryResult<Expr> {
+    fn visit_module(&mut self, module: &Module, state: &mut FerryState) -> FerryResult<Expr> {
         let mut checked_fns = vec![];
 
         for function in module.functions.clone() {
@@ -936,7 +926,7 @@ impl ExprVisitor<FerryResult<Expr>, &mut FerryState> for &mut FerryTypechecker {
         }))
     }
 
-    fn visit_import(&mut self, import: &mut Import, state: &mut FerryState) -> FerryResult<Expr> {
+    fn visit_import(&mut self, import: &Import, state: &mut FerryState) -> FerryResult<Expr> {
         let mut checked_fns = vec![];
 
         for function in import.functions.clone() {


### PR DESCRIPTION
Refactor the visitor pattern for tree-walking to use `&Expr` instead of `&mut Expr` to help prevent unneeded cloning.