### PR TITLE
Cleanup

### DIFF
--- a/examples/fib2.feri
+++ b/examples/fib2.feri
@@ -1,0 +1,11 @@
+import std
+
+// this will require a sequence operator to function correctly
+def fn fib(n: Int) -> Int: 
+    if n == 0 then: (0) else: (
+        if n == 1 then: (1) else (
+    if modulo(n, 2) == 0 then:
+        (fib(n / 2) * (fib((n / 2) + 1) * 2 - fib(n / 2)))
+    else: 
+       ( fib(n / 2) * fib(n / 2) + fib((n / 2) + 1) * fib((n / 2) + 1))
+))

--- a/examples/perf.rs
+++ b/examples/perf.rs
@@ -3,9 +3,15 @@
 use std::{fs, time::Instant};
 
 fn main() {
-    hello();
-    euler_1();
-    fib();
+    for _ in 1..25 {
+        hello();
+    }
+    for _ in 1..25 {
+        euler_1();
+    }
+    for _ in 1..25 {
+        fib();
+    }
 }
 
 // #[expect(unused)]

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     state::{
         types::FerryType,
-        value::{Value, FuncVal},
+        value::{FuncVal, Value},
         State,
     },
 };
@@ -42,11 +42,7 @@ impl Ir {
         Self { heap_ptr: 0x00 }
     }
 
-    pub fn lower(
-        &mut self,
-        typed_ast: &[Expr],
-        state: &mut State,
-    ) -> FerryResult<Vec<Opcode>> {
+    pub fn lower(&mut self, typed_ast: &[Expr], state: &mut State) -> FerryResult<Vec<Opcode>> {
         let mut program = vec![];
         let mut functions = vec![];
 
@@ -73,25 +69,11 @@ impl Ir {
 
         program.push(Opcode::Return);
 
-        // state.add_symbol(
-        //     &"main".to_string(),
-        //     Some(FerryValue::Function {
-        //         declaration: None,
-        //         name: "main".into(),
-        //         func_type: FerryType::Untyped,
-        //         instructions: program,
-        //     }),
-        // );
-
-        // program.append(&mut functions);
-
         for (idx, inst) in program.clone().iter().enumerate() {
             if let Opcode::Label(name) = inst {
                 state.add_label(name, idx + 1);
             }
         }
-
-        // println!("{:?}", program);
 
         Ok(program)
     }
@@ -155,11 +137,7 @@ impl ExprVisitor<FerryResult<Vec<Opcode>>, &mut State> for &mut Ir {
         }
     }
 
-    fn visit_binary(
-        &mut self,
-        binary: &Binary,
-        state: &mut State,
-    ) -> FerryResult<Vec<Opcode>> {
+    fn visit_binary(&mut self, binary: &Binary, state: &mut State) -> FerryResult<Vec<Opcode>> {
         if let TokenType::Operator(op) = binary.operator.get_token_type() {
             match op {
                 Op::Add => {
@@ -296,12 +274,6 @@ impl ExprVisitor<FerryResult<Vec<Opcode>>, &mut State> for &mut Ir {
                     Ok(instructions)
                 }
             }
-            // crate::token::TokenType::Value(val) => todo!(),
-            // crate::token::TokenType::Control(ctrl) => todo!(),
-            // crate::token::TokenType::Keyword(kwd) => todo!(),
-            // crate::token::TokenType::Identifier(_) => todo!(),
-            // crate::token::TokenType::Comment(_) => todo!(),
-            // crate::token::TokenType::End => todo!(),
         } else {
             Ok(vec![Opcode::Nop])
         }
@@ -332,11 +304,7 @@ impl ExprVisitor<FerryResult<Vec<Opcode>>, &mut State> for &mut Ir {
         Ok(instructions)
     }
 
-    fn visit_assign(
-        &mut self,
-        assign: &Assign,
-        state: &mut State,
-    ) -> FerryResult<Vec<Opcode>> {
+    fn visit_assign(&mut self, assign: &Assign, state: &mut State) -> FerryResult<Vec<Opcode>> {
         let mut instructions = vec![];
 
         let id = assign.name.clone();
@@ -383,11 +351,7 @@ impl ExprVisitor<FerryResult<Vec<Opcode>>, &mut State> for &mut Ir {
         Ok(instructions)
     }
 
-    fn visit_binding(
-        &mut self,
-        binding: &Binding,
-        state: &mut State,
-    ) -> FerryResult<Vec<Opcode>> {
+    fn visit_binding(&mut self, binding: &Binding, state: &mut State) -> FerryResult<Vec<Opcode>> {
         let mut instructions = vec![];
         let mut value = if let Some(v) = &binding.value {
             self.assemble_opcode(v, state)?
@@ -504,19 +468,11 @@ impl ExprVisitor<FerryResult<Vec<Opcode>>, &mut State> for &mut Ir {
         Ok(instructions)
     }
 
-    fn visit_module(
-        &mut self,
-        module: &Module,
-        state: &mut State,
-    ) -> FerryResult<Vec<Opcode>> {
+    fn visit_module(&mut self, module: &Module, state: &mut State) -> FerryResult<Vec<Opcode>> {
         todo!()
     }
 
-    fn visit_import(
-        &mut self,
-        import: &Import,
-        state: &mut State,
-    ) -> FerryResult<Vec<Opcode>> {
+    fn visit_import(&mut self, import: &Import, state: &mut State) -> FerryResult<Vec<Opcode>> {
         let instructions = vec![];
 
         for function in import.functions.clone() {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -109,7 +109,7 @@ impl Parser {
         )?;
         self.consume(&TT::Control(Ctrl::Colon), "expected ':' after 'then'")?;
         self.consume_newline()?;
-        let then_expr = Box::new(self.s_expression(state)?);
+        let then_expr = Box::new(self.start(state)?);
         self.consume_newline()?;
         let else_expr = if self.peek().get_token_type() == &TT::Keyword(Kwd::Else) {
             self.consume(&TT::Keyword(Kwd::Else), "idk how you got this")?;
@@ -117,7 +117,7 @@ impl Parser {
                 self.consume(&TT::Control(Ctrl::Colon), "colon not consumed")?;
             }
             self.consume_newline()?;
-            Some(Box::new(self.s_expression(state)?))
+            Some(Box::new(self.start(state)?))
         } else {
             None
         };
@@ -799,6 +799,11 @@ impl Parser {
         let mut args = Vec::new();
         let name = expr.get_token().get_id().unwrap_or_default();
 
+        // self.consume(
+        //     &TT::Control(Ctrl::LeftParen),
+        //     "expected '(' after function identifier",
+        // )?;
+
         if !self.check(&TT::Control(Ctrl::RightParen)) {
             loop {
                 args.push(self.assignment(state)?);
@@ -808,7 +813,10 @@ impl Parser {
             }
         }
 
-        let token = self.consume(&TT::Control(Ctrl::RightParen), "expected ')' after '('")?;
+        let token = self.consume(
+            &TT::Control(Ctrl::RightParen),
+            "expected ')' after '(' in function call",
+        )?;
 
         Ok(Expr::Call(Call {
             invoker: Box::new(expr),

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use types::{FerryType, TypeCheckable, Typing};
+use types::{FerryType, Typing};
 use value::Value;
 
 pub(crate) mod types;
@@ -87,9 +87,7 @@ impl Typing for Value {
             Value::Ptr(_) => &FerryType::Pointer,
         }
     }
-}
 
-impl TypeCheckable for Value {
     fn check(&self, other: &FerryType) -> bool {
         self.get_type() == other
     }

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -1,14 +1,25 @@
 use crate::parser::syntax::{Expr, Lit};
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub enum FerryTyping {
     Assigned(FerryType),
     Inferred(FerryType),
+    #[default]
     Untyped,
     Undefined,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+impl FerryTyping {
+    pub(crate) fn assign(assign: &FerryType) -> Self {
+        Self::Assigned(*assign)
+    }
+
+    pub(crate) fn infer(infer: &FerryType) -> Self {
+        Self::Inferred(*infer)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Copy)]
 pub enum FerryType {
     Untyped,
     Undefined,
@@ -22,11 +33,12 @@ pub enum FerryType {
 
 pub trait Typing {
     fn get_type(&self) -> &FerryType;
-}
-
-pub trait TypeCheckable {
     fn check(&self, other: &FerryType) -> bool;
 }
+
+// pub trait TypeCheckable {
+//     fn check(&self, other: &FerryType) -> bool;
+// }
 
 impl Typing for FerryTyping {
     fn get_type(&self) -> &FerryType {
@@ -37,15 +49,17 @@ impl Typing for FerryTyping {
             FerryTyping::Undefined => &FerryType::Undefined,
         }
     }
-}
 
-impl TypeCheckable for FerryTyping {
     fn check(&self, other: &FerryType) -> bool {
         self.get_type() == other
     }
 }
 
-impl TypeCheckable for FerryType {
+impl Typing for FerryType {
+    fn get_type(&self) -> &FerryType {
+        self
+    }
+
     fn check(&self, other: &FerryType) -> bool {
         self == other
     }
@@ -104,9 +118,7 @@ impl Typing for Expr {
             Expr::Module(_) | Expr::Import(_) => &FerryType::Untyped,
         }
     }
-}
 
-impl TypeCheckable for Expr {
     fn check(&self, other: &FerryType) -> bool {
         self.get_type() == other
     }

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -36,10 +36,6 @@ pub trait Typing {
     fn check(&self, other: &FerryType) -> bool;
 }
 
-// pub trait TypeCheckable {
-//     fn check(&self, other: &FerryType) -> bool;
-// }
-
 impl Typing for FerryTyping {
     fn get_type(&self) -> &FerryType {
         match self {

--- a/src/state/value.rs
+++ b/src/state/value.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Error};
+// use anyhow::{anyhow, Error};
 
 use crate::{ir::Opcode, parser::syntax::Function};
 
@@ -31,17 +31,28 @@ impl From<i64> for Value {
     }
 }
 
-impl TryFrom<Value> for i64 {
-    type Error = Error;
-
-    fn try_from(value: Value) -> Result<Self, Self::Error> {
+// Coerces all non-Number values to 0
+impl From<Value> for i64 {
+    fn from(value: Value) -> Self {
         if let Value::Number(v) = value {
-            Ok(v)
+            v
         } else {
-            Err(anyhow!("not an i64"))
+            0
         }
     }
 }
+
+// impl TryFrom<Value> for i64 {
+//     type Error = Error;
+
+//     fn try_from(value: Value) -> Result<Self, Self::Error> {
+//         if let Value::Number(v) = value {
+//             Ok(v)
+//         } else {
+//             Err(anyhow!("not an i64"))
+//         }
+//     }
+// }
 
 impl From<String> for Value {
     fn from(value: String) -> Self {
@@ -49,17 +60,28 @@ impl From<String> for Value {
     }
 }
 
-impl TryFrom<Value> for String {
-    type Error = Error;
-
-    fn try_from(value: Value) -> Result<Self, Self::Error> {
+// coerces all non-Str to be empty Strings
+impl From<Value> for String {
+    fn from(value: Value) -> Self {
         if let Value::Str(v) = value {
-            Ok(v)
+            v
         } else {
-            Err(anyhow!("not a String"))
+            String::new()
         }
     }
 }
+
+// impl TryFrom<Value> for String {
+//     type Error = Error;
+
+//     fn try_from(value: Value) -> Result<Self, Self::Error> {
+//         if let Value::Str(v) = value {
+//             Ok(v)
+//         } else {
+//             Err(anyhow!("not a String"))
+//         }
+//     }
+// }
 
 impl From<Vec<Value>> for Value {
     fn from(value: Vec<Value>) -> Value {
@@ -67,17 +89,28 @@ impl From<Vec<Value>> for Value {
     }
 }
 
-impl TryFrom<Value> for Vec<Value> {
-    type Error = Error;
-
-    fn try_from(value: Value) -> Result<Self, Self::Error> {
+// coerces empty Vec<Value> for List
+impl From<Value> for Vec<Value> {
+    fn from(value: Value) -> Self {
         if let Value::List(v) = value {
-            Ok(v)
+            v
         } else {
-            Err(anyhow!("not a Vec<FerryValue>"))
+            Vec::new()
         }
     }
 }
+
+// impl TryFrom<Value> for Vec<Value> {
+//     type Error = Error;
+
+//     fn try_from(value: Value) -> Result<Self, Self::Error> {
+//         if let Value::List(v) = value {
+//             Ok(v)
+//         } else {
+//             Err(anyhow!("not a Vec<FerryValue>"))
+//         }
+//     }
+// }
 
 impl From<bool> for Value {
     fn from(value: bool) -> Self {
@@ -85,17 +118,27 @@ impl From<bool> for Value {
     }
 }
 
-impl TryFrom<Value> for bool {
-    type Error = Error;
-
-    fn try_from(value: Value) -> Result<Self, Self::Error> {
+impl From<Value> for bool {
+    fn from(value: Value) -> Self {
         if let Value::Boolean(v) = value {
-            Ok(v)
+            v
         } else {
-            Err(anyhow!("Not a bool"))
+            false
         }
     }
 }
+
+// impl TryFrom<Value> for bool {
+//     type Error = Error;
+
+//     fn try_from(value: Value) -> Result<Self, Self::Error> {
+//         if let Value::Boolean(v) = value {
+//             Ok(v)
+//         } else {
+//             Err(anyhow!("Not a bool"))
+//         }
+//     }
+// }
 
 impl From<FuncVal> for Value {
     fn from(value: FuncVal) -> Self {
@@ -103,17 +146,33 @@ impl From<FuncVal> for Value {
     }
 }
 
-impl TryFrom<Value> for FuncVal {
-    type Error = Error;
-
-    fn try_from(value: Value) -> Result<Self, Self::Error> {
+impl From<Value> for FuncVal {
+    fn from(value: Value) -> Self {
         if let Value::Function(v) = value {
-            Ok(v)
+            v
         } else {
-            Err(anyhow!("Not a FuncVal"))
+            Self {
+                declaration: None,
+                name: String::new(),
+                func_type: FerryType::Undefined,
+                instructions: vec![Opcode::Nop],
+                arity: 0,
+            }
         }
     }
 }
+
+// impl TryFrom<Value> for FuncVal {
+//     type Error = Error;
+
+//     fn try_from(value: Value) -> Result<Self, Self::Error> {
+//         if let Value::Function(v) = value {
+//             Ok(v)
+//         } else {
+//             Err(anyhow!("Not a FuncVal"))
+//         }
+//     }
+// }
 
 impl From<u8> for Value {
     fn from(value: u8) -> Self {
@@ -121,17 +180,28 @@ impl From<u8> for Value {
     }
 }
 
-impl TryFrom<Value> for u8 {
-    type Error = Error;
-
-    fn try_from(value: Value) -> Result<Self, Self::Error> {
+// null pointers????? null pointers....
+impl From<Value> for u8 {
+    fn from(value: Value) -> Self {
         if let Value::Ptr(v) = value {
-            Ok(v)
+            v
         } else {
-            Err(anyhow!("Not a Ptr"))
+            0
         }
     }
 }
+
+// impl TryFrom<Value> for u8 {
+//     type Error = Error;
+
+//     fn try_from(value: Value) -> Result<Self, Self::Error> {
+//         if let Value::Ptr(v) = value {
+//             Ok(v)
+//         } else {
+//             Err(anyhow!("Not a Ptr"))
+//         }
+//     }
+// }
 
 impl From<()> for Value {
     fn from(_value: ()) -> Self {
@@ -139,14 +209,18 @@ impl From<()> for Value {
     }
 }
 
-impl TryFrom<Value> for () {
-    type Error = Error;
-
-    fn try_from(value: Value) -> Result<Self, Self::Error> {
-        if Value::Unit == value {
-            Ok(())
-        } else {
-            Err(anyhow!("not ()"))
-        }
-    }
+impl From<Value> for () {
+    fn from(_value: Value) -> Self {}
 }
+
+// impl TryFrom<Value> for () {
+//     type Error = Error;
+
+//     fn try_from(value: Value) -> Result<Self, Self::Error> {
+//         if Value::Unit == value {
+//             Ok(())
+//         } else {
+//             Err(anyhow!("not ()"))
+//         }
+//     }
+// }

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -159,18 +159,8 @@ impl Vm {
                 }
                 Opcode::Add => {
                     if self.frames[self.fp].stack.len() >= 2 {
-                        let right: i64 = self.frames[self.fp]
-                            .stack
-                            .pop()
-                            .unwrap()
-                            .try_into()
-                            .unwrap();
-                        let left: i64 = self.frames[self.fp]
-                            .stack
-                            .pop()
-                            .unwrap()
-                            .try_into()
-                            .unwrap();
+                        let right: i64 = self.frames[self.fp].stack.pop().unwrap().into();
+                        let left: i64 = self.frames[self.fp].stack.pop().unwrap().into();
                         let res: i64 = left + right;
 
                         self.frames[self.fp].stack.push(res.into());
@@ -182,18 +172,8 @@ impl Vm {
                 }
                 Opcode::Sub => {
                     if self.frames[self.fp].stack.len() >= 2 {
-                        let right: i64 = self.frames[self.fp]
-                            .stack
-                            .pop()
-                            .unwrap()
-                            .try_into()
-                            .unwrap();
-                        let left: i64 = self.frames[self.fp]
-                            .stack
-                            .pop()
-                            .unwrap()
-                            .try_into()
-                            .unwrap();
+                        let right: i64 = self.frames[self.fp].stack.pop().unwrap().into();
+                        let left: i64 = self.frames[self.fp].stack.pop().unwrap().into();
                         let res: i64 = left - right;
                         self.frames[self.fp].stack.push(res.into());
                     } else {
@@ -204,18 +184,8 @@ impl Vm {
                 }
                 Opcode::Mul => {
                     if self.frames[self.fp].stack.len() >= 2 {
-                        let right: i64 = self.frames[self.fp]
-                            .stack
-                            .pop()
-                            .unwrap()
-                            .try_into()
-                            .unwrap();
-                        let left: i64 = self.frames[self.fp]
-                            .stack
-                            .pop()
-                            .unwrap()
-                            .try_into()
-                            .unwrap();
+                        let right: i64 = self.frames[self.fp].stack.pop().unwrap().into();
+                        let left: i64 = self.frames[self.fp].stack.pop().unwrap().into();
                         let res: i64 = left * right;
                         self.frames[self.fp].stack.push(res.into());
                     } else {
@@ -226,18 +196,8 @@ impl Vm {
                 }
                 Opcode::Div => {
                     if self.frames[self.fp].stack.len() >= 2 {
-                        let right: i64 = self.frames[self.fp]
-                            .stack
-                            .pop()
-                            .unwrap()
-                            .try_into()
-                            .unwrap();
-                        let left: i64 = self.frames[self.fp]
-                            .stack
-                            .pop()
-                            .unwrap()
-                            .try_into()
-                            .unwrap();
+                        let right: i64 = self.frames[self.fp].stack.pop().unwrap().into();
+                        let left: i64 = self.frames[self.fp].stack.pop().unwrap().into();
                         if right == 0 {
                             return Err(FerryVmError::RuntimeError {
                                 advice: "DIVIDE BY ZERO".into(),
@@ -261,77 +221,32 @@ impl Vm {
                     }
                 }
                 Opcode::Equal => {
-                    let right: i64 = self.frames[self.fp]
-                        .stack
-                        .pop()
-                        .unwrap()
-                        .try_into()
-                        .unwrap();
-                    let left: i64 = self.frames[self.fp]
-                        .stack
-                        .pop()
-                        .unwrap()
-                        .try_into()
-                        .unwrap();
+                    let right: i64 = self.frames[self.fp].stack.pop().unwrap().into();
+                    let left: i64 = self.frames[self.fp].stack.pop().unwrap().into();
                     let res = left == right;
                     self.frames[self.fp].stack.push(res.into());
                 }
                 Opcode::Greater => {
-                    let right: i64 = self.frames[self.fp]
-                        .stack
-                        .pop()
-                        .unwrap()
-                        .try_into()
-                        .unwrap();
-                    let left: i64 = self.frames[self.fp]
-                        .stack
-                        .pop()
-                        .unwrap()
-                        .try_into()
-                        .unwrap();
+                    let right: i64 = self.frames[self.fp].stack.pop().unwrap().into();
+                    let left: i64 = self.frames[self.fp].stack.pop().unwrap().into();
                     let res = left > right;
                     self.frames[self.fp].stack.push(res.into());
                 }
                 Opcode::Lesser => {
-                    let right: i64 = self.frames[self.fp]
-                        .stack
-                        .pop()
-                        .unwrap()
-                        .try_into()
-                        .unwrap();
-                    let left: i64 = self.frames[self.fp]
-                        .stack
-                        .pop()
-                        .unwrap()
-                        .try_into()
-                        .unwrap();
+                    let right: i64 = self.frames[self.fp].stack.pop().unwrap().into();
+                    let left: i64 = self.frames[self.fp].stack.pop().unwrap().into();
                     let res = left < right;
                     self.frames[self.fp].stack.push(res.into());
                 }
                 Opcode::GetI => {
-                    let right: i64 = self.frames[self.fp]
-                        .stack
-                        .pop()
-                        .unwrap()
-                        .try_into()
-                        .unwrap();
-                    let left: Vec<Value> = self.frames[self.fp]
-                        .stack
-                        .pop()
-                        .unwrap()
-                        .try_into()
-                        .unwrap();
+                    let right: i64 = self.frames[self.fp].stack.pop().unwrap().into();
+                    let left: Vec<Value> = self.frames[self.fp].stack.pop().unwrap().into();
                     let res: Value = left[right as usize].clone();
                     self.frames[self.fp].stack.push(res);
                 }
                 Opcode::Cons => {
                     let right: Value = self.frames[self.fp].stack.pop().unwrap();
-                    let mut left: Vec<Value> = self.frames[self.fp]
-                        .stack
-                        .pop()
-                        .unwrap()
-                        .try_into()
-                        .unwrap();
+                    let mut left: Vec<Value> = self.frames[self.fp].stack.pop().unwrap().into();
                     let res: Vec<Value>;
                     if let Value::List(l) = right {
                         res = [left, l].concat();
@@ -354,12 +269,7 @@ impl Vm {
                     self.frames[self.fp].pc -= offset;
                 }
                 Opcode::Iter => {
-                    let iter: Vec<Value> = self.frames[self.fp]
-                        .stack
-                        .pop()
-                        .unwrap()
-                        .try_into()
-                        .unwrap();
+                    let iter: Vec<Value> = self.frames[self.fp].stack.pop().unwrap().into();
 
                     let (head, tail) = iter.split_first().unwrap();
 

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -27,6 +27,26 @@ struct Frame {
     pub locals: HashMap<String, Value>,
 }
 
+impl Frame {
+    fn new(function: Vec<Opcode>) -> Self {
+        Self {
+            stack: Vec::new(),
+            pc: 0,
+            function: Rc::new(RefCell::new(function)),
+            locals: HashMap::new(),
+        }
+    }
+
+    fn new_from_stack(function: Vec<Opcode>, stack: Vec<Value>) -> Self {
+        Self {
+            stack,
+            pc: 0,
+            function: Rc::new(RefCell::new(function)),
+            locals: HashMap::new(),
+        }
+    }
+}
+
 pub struct Vm {
     // instructions: Vec<FerryOpcode>,
     frames: Vec<Frame>,
@@ -66,13 +86,7 @@ impl Vm {
         instructions: Vec<Opcode>,
         state: &mut State,
     ) -> FerryResult<Value> {
-        let program = Rc::new(RefCell::new(instructions));
-        let mut frame = Frame {
-            stack: vec![],
-            pc: 0,
-            function: program,
-            locals: HashMap::new(),
-        };
+        let mut frame = Frame::new(instructions);
 
         for (key, value) in state.load_memory().drain() {
             frame.locals.insert(key, value.unwrap());
@@ -350,13 +364,9 @@ impl Vm {
                     let (head, tail) = iter.split_first().unwrap();
 
                     let tail_len = tail.len() as i64;
-                    self.frames[self.fp]
-                        .stack
-                        .push(Value::List(tail.into()));
+                    self.frames[self.fp].stack.push(Value::List(tail.into()));
                     // push len onto stack
-                    self.frames[self.fp]
-                        .stack
-                        .push(Value::Number(tail_len));
+                    self.frames[self.fp].stack.push(Value::Number(tail_len));
                     // push value of variable assignment
                     self.frames[self.fp].stack.push(head.clone());
                 }
@@ -372,12 +382,7 @@ impl Vm {
                         for _ in (stack_len - f.arity)..stack_len {
                             frame_stack.push(self.frames[self.fp].stack.pop().unwrap());
                         }
-                        let frame = Frame {
-                            stack: frame_stack,
-                            pc: 0,
-                            function: Rc::new(RefCell::new(f.instructions)),
-                            locals: HashMap::new(),
-                        };
+                        let frame = Frame::new_from_stack(f.instructions, frame_stack);
 
                         self.frames.push(frame);
                         self.fp += 1;
@@ -415,11 +420,7 @@ mod tests {
     #[ignore]
     fn check_load() {
         let mut vm = Vm::new();
-        let instructions = vec![
-            Opcode::LoadI(1),
-            Opcode::LoadI(2),
-            Opcode::Halt,
-        ];
+        let instructions = vec![Opcode::LoadI(1), Opcode::LoadI(2), Opcode::Halt];
         vm.interpret(instructions, &mut State::new()).unwrap();
         assert!(vm.frames[vm.fp].stack == vec![Value::Number(1), Value::Number(2)]);
     }
@@ -434,8 +435,6 @@ mod tests {
             Opcode::Return,
             Opcode::Halt,
         ];
-        assert!(
-            vm.interpret(instructions, &mut State::new()).unwrap() == Value::Number(3)
-        );
+        assert!(vm.interpret(instructions, &mut State::new()).unwrap() == Value::Number(3));
     }
 }


### PR DESCRIPTION
- `Frame` has methods for constructing new `Frame`s without needing to manually create full struct instance
- Consolidate type methods onto `Typing` instead of splitting between two `trait`s
- Implemented `From` for `Value` over `TryFrom`, thus giving default / placeholder values for incorrectly accessed data. This will be undefined behavior but the type system should, in theory, prevent this from happening.
- `then` and `else` now accept the full syntax in their bodies, although alas the full syntax is still only one expression